### PR TITLE
Fixed Eng name

### DIFF
--- a/data/859/078/01/85907801.geojson
+++ b/data/859/078/01/85907801.geojson
@@ -28,9 +28,6 @@
     "mz:min_zoom":13.0,
     "mz:tier_locality":3,
     "mz:tier_metro":30,
-    "name:Eng_x_variant":[
-        "Old City"
-    ],
     "name:aze_x_preferred":[
         "\u018fski Riqa"
     ],
@@ -180,7 +177,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1568233169,
     "wof:name":"Vecriga",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes the a portion of whosonfirst-data/whosonfirst-data#1709

This PR removes any bunk iso codes/name properties and empty name lists. Unfortunately, the Git history does not reveal where these empty name strings come from. I also ran this record against wikidata to gain new names, but no new names were found.

This does not require PIP work. Can be merged once approved.