### PR TITLE
geom_alt props

### DIFF
--- a/data/101/751/781/101751781.geojson
+++ b/data/101/751/781/101751781.geojson
@@ -459,6 +459,9 @@
         "qs_pg:id":901258
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6903d003d7a1bd273bf7a6e58b25a88e",
     "wof:hierarchy":[
         {
@@ -469,7 +472,7 @@
         }
     ],
     "wof:id":101751781,
-    "wof:lastmodified":1566599065,
+    "wof:lastmodified":1582313198,
     "wof:name":"Daugavpils",
     "wof:parent_id":85685795,
     "wof:placetype":"locality",

--- a/data/101/751/783/101751783.geojson
+++ b/data/101/751/783/101751783.geojson
@@ -403,6 +403,9 @@
         "wk:page":"Liep\u0101ja"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2fa174f6bf763d5c7a542dd5f75c33c7",
     "wof:hierarchy":[
         {
@@ -413,7 +416,7 @@
         }
     ],
     "wof:id":101751783,
-    "wof:lastmodified":1566599065,
+    "wof:lastmodified":1582313198,
     "wof:name":"Liep\u0101ja",
     "wof:parent_id":85685799,
     "wof:placetype":"locality",

--- a/data/101/751/785/101751785.geojson
+++ b/data/101/751/785/101751785.geojson
@@ -413,6 +413,9 @@
         "wd:id":"Q179830"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fd2e7003c483acc9c0bbf0a3358f4e2d",
     "wof:hierarchy":[
         {
@@ -426,7 +429,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"Jelgava",
     "wof:parent_id":85685881,
     "wof:placetype":"locality",

--- a/data/101/751/787/101751787.geojson
+++ b/data/101/751/787/101751787.geojson
@@ -306,6 +306,9 @@
         "wk:page":"J\u016brmala"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c809ef0bff402369434e1b9dde8a716",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
         }
     ],
     "wof:id":101751787,
-    "wof:lastmodified":1566599065,
+    "wof:lastmodified":1582313198,
     "wof:name":"J\u016brmala",
     "wof:parent_id":85686031,
     "wof:placetype":"locality",

--- a/data/101/751/789/101751789.geojson
+++ b/data/101/751/789/101751789.geojson
@@ -734,6 +734,9 @@
         85686065
     ],
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"355fb81e2781a0318d70cdc9f1d995be",
     "wof:hierarchy":[
         {
@@ -744,7 +747,7 @@
         }
     ],
     "wof:id":101751789,
-    "wof:lastmodified":1566599065,
+    "wof:lastmodified":1582313198,
     "wof:megacity":0,
     "wof:name":"R\u012bga",
     "wof:parent_id":85686065,

--- a/data/101/816/275/101816275.geojson
+++ b/data/101/816/275/101816275.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Priekule, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea888e69f9af5ea2e67eb386581e66a1",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101816275,
-    "wof:lastmodified":1566599052,
+    "wof:lastmodified":1582313195,
     "wof:name":"Priekule",
     "wof:parent_id":85685803,
     "wof:placetype":"locality",

--- a/data/101/816/277/101816277.geojson
+++ b/data/101/816/277/101816277.geojson
@@ -144,6 +144,9 @@
         "qs_pg:id":124648
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f31775160f867670cc59cf1f4a4a55a5",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":101816277,
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Il\u016bkste",
     "wof:parent_id":85685815,
     "wof:placetype":"locality",

--- a/data/101/816/279/101816279.geojson
+++ b/data/101/816/279/101816279.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Subate"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f620543b7b8fc6ba59275ad359b0638d",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101816279,
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Subate",
     "wof:parent_id":85685815,
     "wof:placetype":"locality",

--- a/data/101/816/281/101816281.geojson
+++ b/data/101/816/281/101816281.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Akn\u012bste"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76816e27732dcf9f1cc33b2a1c5b1453",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101816281,
-    "wof:lastmodified":1566599053,
+    "wof:lastmodified":1582313195,
     "wof:name":"Akn\u012bste",
     "wof:parent_id":85685819,
     "wof:placetype":"locality",

--- a/data/101/816/285/101816285.geojson
+++ b/data/101/816/285/101816285.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Kr\u0101slava"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43e261521f49bc1e97627a75e302c7ea",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
         }
     ],
     "wof:id":101816285,
-    "wof:lastmodified":1566599058,
+    "wof:lastmodified":1582313197,
     "wof:name":"Kr\u0101slava",
     "wof:parent_id":85685833,
     "wof:placetype":"locality",

--- a/data/101/816/291/101816291.geojson
+++ b/data/101/816/291/101816291.geojson
@@ -149,6 +149,9 @@
         "wk:page":"Auce"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e25a6a011c4482d18225d736b39ab61",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":101816291,
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Auce",
     "wof:parent_id":85685839,
     "wof:placetype":"locality",

--- a/data/101/816/293/101816293.geojson
+++ b/data/101/816/293/101816293.geojson
@@ -185,6 +185,9 @@
         "wk:page":"Bauska"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"936bdf6a55927d3d1c363931571f5b2e",
     "wof:hierarchy":[
         {
@@ -195,7 +198,7 @@
         }
     ],
     "wof:id":101816293,
-    "wof:lastmodified":1566599054,
+    "wof:lastmodified":1582313196,
     "wof:name":"Bauska",
     "wof:parent_id":85685851,
     "wof:placetype":"locality",

--- a/data/101/816/297/101816297.geojson
+++ b/data/101/816/297/101816297.geojson
@@ -174,6 +174,9 @@
         "wd:id":"Q411723"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c8d4d3192cc5f1ec00c9e5135372f0f3",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Aizpute",
     "wof:parent_id":85685867,
     "wof:placetype":"locality",

--- a/data/101/816/299/101816299.geojson
+++ b/data/101/816/299/101816299.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Skrunda"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"618259268eefe14dad33da7c34a6d7de",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599060,
+    "wof:lastmodified":1582313197,
     "wof:name":"Skrunda",
     "wof:parent_id":85685871,
     "wof:placetype":"locality",

--- a/data/101/816/301/101816301.geojson
+++ b/data/101/816/301/101816301.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Vies\u012bte"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4b41e95f3a9fa82a0670a96165e968e4",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101816301,
-    "wof:lastmodified":1566599051,
+    "wof:lastmodified":1582313195,
     "wof:name":"Vies\u012bte",
     "wof:parent_id":85685875,
     "wof:placetype":"locality",

--- a/data/101/816/303/101816303.geojson
+++ b/data/101/816/303/101816303.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Dagda, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6f9e10f1067a8fbccbca92b29270ce5",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101816303,
-    "wof:lastmodified":1566599056,
+    "wof:lastmodified":1582313196,
     "wof:name":"Dagda",
     "wof:parent_id":85685893,
     "wof:placetype":"locality",

--- a/data/101/816/305/101816305.geojson
+++ b/data/101/816/305/101816305.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Iecava"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e71aad77ae0d754f1c55a2e6af864714",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
         }
     ],
     "wof:id":101816305,
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Iecava",
     "wof:parent_id":85685905,
     "wof:placetype":"locality",

--- a/data/101/816/311/101816311.geojson
+++ b/data/101/816/311/101816311.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Ozolnieki"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d58d5bbf2c9ea96c633684a1c69bc1a",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101816311,
-    "wof:lastmodified":1566599060,
+    "wof:lastmodified":1582313197,
     "wof:name":"Ozolnieki",
     "wof:parent_id":85685907,
     "wof:placetype":"locality",

--- a/data/101/816/315/101816315.geojson
+++ b/data/101/816/315/101816315.geojson
@@ -172,6 +172,9 @@
         "wk:page":"Dobele"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"753612d50b23937ffe42c6f6fbd94220",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":101816315,
-    "wof:lastmodified":1566599055,
+    "wof:lastmodified":1582313196,
     "wof:name":"Dobele",
     "wof:parent_id":85685925,
     "wof:placetype":"locality",

--- a/data/101/816/317/101816317.geojson
+++ b/data/101/816/317/101816317.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Prei\u013ci"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85aeb4c4832ca58f741164e03f2c29f2",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":101816317,
-    "wof:lastmodified":1566599061,
+    "wof:lastmodified":1582313197,
     "wof:name":"Prei\u013ci",
     "wof:parent_id":85685929,
     "wof:placetype":"locality",

--- a/data/101/816/319/101816319.geojson
+++ b/data/101/816/319/101816319.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Saldus"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b9d7f5f8b3d9bbf8f326cd2dd2caf897",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101816319,
-    "wof:lastmodified":1566599062,
+    "wof:lastmodified":1582313197,
     "wof:name":"Saldus",
     "wof:parent_id":85685935,
     "wof:placetype":"locality",

--- a/data/101/816/321/101816321.geojson
+++ b/data/101/816/321/101816321.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Vecumnieki"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f4e13ec0662044b8036b4b828a1b184",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101816321,
-    "wof:lastmodified":1566599062,
+    "wof:lastmodified":1582313197,
     "wof:name":"Vecumnieki",
     "wof:parent_id":85685939,
     "wof:placetype":"locality",

--- a/data/101/816/323/101816323.geojson
+++ b/data/101/816/323/101816323.geojson
@@ -143,6 +143,9 @@
         "wk:page":"L\u012bv\u0101ni"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e7316cb687221b0923e3fdc3db1d499d",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101816323,
-    "wof:lastmodified":1566599054,
+    "wof:lastmodified":1582313196,
     "wof:name":"L\u012bv\u0101ni",
     "wof:parent_id":85685943,
     "wof:placetype":"locality",

--- a/data/101/816/327/101816327.geojson
+++ b/data/101/816/327/101816327.geojson
@@ -151,6 +151,9 @@
         "wk:page":"Jaunjelgava"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0afa6ee03cf3e7df43ed6492b30ba2b0",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101816327,
-    "wof:lastmodified":1566599060,
+    "wof:lastmodified":1582313197,
     "wof:name":"Jaunjelgava",
     "wof:parent_id":85685947,
     "wof:placetype":"locality",

--- a/data/101/816/331/101816331.geojson
+++ b/data/101/816/331/101816331.geojson
@@ -145,6 +145,9 @@
         "wk:page":"Baldone"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14cd064cbd77bb7cd634714791771613",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":101816331,
-    "wof:lastmodified":1566599050,
+    "wof:lastmodified":1582313195,
     "wof:name":"Baldone",
     "wof:parent_id":85685957,
     "wof:placetype":"locality",

--- a/data/101/816/333/101816333.geojson
+++ b/data/101/816/333/101816333.geojson
@@ -179,6 +179,9 @@
         "wk:page":"Aizkraukle"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"275b9236587e135a7bedab81e08aa315",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":101816333,
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Aizkraukle",
     "wof:parent_id":85685965,
     "wof:placetype":"locality",

--- a/data/101/816/347/101816347.geojson
+++ b/data/101/816/347/101816347.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Zilupe"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd3c0ea959df581e84b43cf184a5b93d",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":101816347,
-    "wof:lastmodified":1566599055,
+    "wof:lastmodified":1582313196,
     "wof:name":"Zilupe",
     "wof:parent_id":85685987,
     "wof:placetype":"locality",

--- a/data/101/816/349/101816349.geojson
+++ b/data/101/816/349/101816349.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Lielv\u0101rde"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cfb78e0bd35c9886fab882bf1daa5e46",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101816349,
-    "wof:lastmodified":1566599055,
+    "wof:lastmodified":1582313196,
     "wof:name":"Lielv\u0101rde",
     "wof:parent_id":85685995,
     "wof:placetype":"locality",

--- a/data/101/816/351/101816351.geojson
+++ b/data/101/816/351/101816351.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1098500
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3067bd67e9ae255bd361884a3031594",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":101816351,
-    "wof:lastmodified":1566599056,
+    "wof:lastmodified":1582313196,
     "wof:name":"Jumprava",
     "wof:parent_id":85685995,
     "wof:placetype":"locality",

--- a/data/101/816/353/101816353.geojson
+++ b/data/101/816/353/101816353.geojson
@@ -378,6 +378,9 @@
         "wk:page":"R\u0113zekne"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e615ba5f2312c87a2104ac2f747ce4a2",
     "wof:hierarchy":[
         {
@@ -388,7 +391,7 @@
         }
     ],
     "wof:id":101816353,
-    "wof:lastmodified":1566599050,
+    "wof:lastmodified":1582313195,
     "wof:name":"R\u0113zekne",
     "wof:parent_id":85686001,
     "wof:placetype":"locality",

--- a/data/101/816/355/101816355.geojson
+++ b/data/101/816/355/101816355.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":1349971
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1e5728e5ccb2306bc78552d2a0b014d",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101816355,
-    "wof:lastmodified":1566599051,
+    "wof:lastmodified":1582313195,
     "wof:name":"Skulte",
     "wof:parent_id":85686007,
     "wof:placetype":"locality",

--- a/data/101/816/357/101816357.geojson
+++ b/data/101/816/357/101816357.geojson
@@ -150,6 +150,9 @@
         "wk:page":"\u0136egums"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61111f54d37616adc111f3532e40c82a",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":101816357,
-    "wof:lastmodified":1566599056,
+    "wof:lastmodified":1582313196,
     "wof:name":"\u0136egums",
     "wof:parent_id":85686011,
     "wof:placetype":"locality",

--- a/data/101/816/363/101816363.geojson
+++ b/data/101/816/363/101816363.geojson
@@ -157,6 +157,9 @@
         "wk:page":"Salaspils"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d36eb81f3b176936cedf46e660225fc",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":101816363,
-    "wof:lastmodified":1566599051,
+    "wof:lastmodified":1582313195,
     "wof:name":"Salaspils",
     "wof:parent_id":85686015,
     "wof:placetype":"locality",

--- a/data/101/816/367/101816367.geojson
+++ b/data/101/816/367/101816367.geojson
@@ -151,6 +151,9 @@
         "wd:id":"Q753029"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3bd5b24a87793f649ae7115ded6b95c",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":101816367,
-    "wof:lastmodified":1566599056,
+    "wof:lastmodified":1582313196,
     "wof:name":"Ik\u0161\u0137ile",
     "wof:parent_id":85686017,
     "wof:placetype":"locality",

--- a/data/101/816/369/101816369.geojson
+++ b/data/101/816/369/101816369.geojson
@@ -239,6 +239,9 @@
         "wk:page":"Ulbroka"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"489d65bfc27ce01bfb226b1b66c7a94e",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
         }
     ],
     "wof:id":101816369,
-    "wof:lastmodified":1566599056,
+    "wof:lastmodified":1582313196,
     "wof:name":"Ulbroka",
     "wof:parent_id":85686033,
     "wof:placetype":"locality",

--- a/data/101/816/371/101816371.geojson
+++ b/data/101/816/371/101816371.geojson
@@ -164,6 +164,9 @@
         "wk:page":"Ludza"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5bdc385c03e4181b5b3726d09333be80",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":101816371,
-    "wof:lastmodified":1566599055,
+    "wof:lastmodified":1582313196,
     "wof:name":"Ludza",
     "wof:parent_id":85686037,
     "wof:placetype":"locality",

--- a/data/101/816/373/101816373.geojson
+++ b/data/101/816/373/101816373.geojson
@@ -188,6 +188,9 @@
         "wk:page":"Kuld\u012bga"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4090c5732df8ae6cc08d2ea96dfefed3",
     "wof:hierarchy":[
         {
@@ -198,7 +201,7 @@
         }
     ],
     "wof:id":101816373,
-    "wof:lastmodified":1566599061,
+    "wof:lastmodified":1582313197,
     "wof:name":"Kuld\u012bga",
     "wof:parent_id":85686043,
     "wof:placetype":"locality",

--- a/data/101/816/381/101816381.geojson
+++ b/data/101/816/381/101816381.geojson
@@ -141,6 +141,9 @@
         "qs_pg:id":124646
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76204b274d252865d1e66104a30237cd",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101816381,
-    "wof:lastmodified":1566599062,
+    "wof:lastmodified":1582313197,
     "wof:name":"Kandava",
     "wof:parent_id":85686061,
     "wof:placetype":"locality",

--- a/data/101/816/383/101816383.geojson
+++ b/data/101/816/383/101816383.geojson
@@ -55,6 +55,9 @@
         "qs_pg:id":1182520
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c200fe3026af7b29ba4c5d32e3fdefbe",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":101816383,
-    "wof:lastmodified":1566599054,
+    "wof:lastmodified":1582313196,
     "wof:name":"Garkalne",
     "wof:parent_id":85686073,
     "wof:placetype":"locality",

--- a/data/101/816/385/101816385.geojson
+++ b/data/101/816/385/101816385.geojson
@@ -180,6 +180,9 @@
         "wk:page":"Ogre, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7db66afcfe2b0f6a2186184534e3f794",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":101816385,
-    "wof:lastmodified":1566599055,
+    "wof:lastmodified":1582313196,
     "wof:name":"Ogre",
     "wof:parent_id":85686079,
     "wof:placetype":"locality",

--- a/data/101/816/387/101816387.geojson
+++ b/data/101/816/387/101816387.geojson
@@ -178,6 +178,9 @@
         "wk:page":"Tukums"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2b9edd2362afedefc9fd494478909bf",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":101816387,
-    "wof:lastmodified":1566599061,
+    "wof:lastmodified":1582313197,
     "wof:name":"Tukums",
     "wof:parent_id":85686083,
     "wof:placetype":"locality",

--- a/data/101/816/395/101816395.geojson
+++ b/data/101/816/395/101816395.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Engure"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ba19c66fa5cfea5b7f43a1a5ae13796",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101816395,
-    "wof:lastmodified":1566599055,
+    "wof:lastmodified":1582313196,
     "wof:name":"Engure",
     "wof:parent_id":85686103,
     "wof:placetype":"locality",

--- a/data/101/816/399/101816399.geojson
+++ b/data/101/816/399/101816399.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Carnikava"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"882662b4e3173c40a7455fa59f796a7f",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101816399,
-    "wof:lastmodified":1566599051,
+    "wof:lastmodified":1582313195,
     "wof:name":"Carnikava",
     "wof:parent_id":85686107,
     "wof:placetype":"locality",

--- a/data/101/816/401/101816401.geojson
+++ b/data/101/816/401/101816401.geojson
@@ -107,6 +107,9 @@
         "wk:page":"\u0100da\u017ei"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92cda3b66667d97eddcce8b56879d66b",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101816401,
-    "wof:lastmodified":1566599053,
+    "wof:lastmodified":1582313196,
     "wof:name":"\u0100da\u017ei",
     "wof:parent_id":85686113,
     "wof:placetype":"locality",

--- a/data/101/816/405/101816405.geojson
+++ b/data/101/816/405/101816405.geojson
@@ -396,6 +396,9 @@
         "wd:id":"Q104036"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63a6abdd361a38a1ae3acd7288bda19d",
     "wof:hierarchy":[
         {
@@ -409,7 +412,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Ventspils",
     "wof:parent_id":85686123,
     "wof:placetype":"locality",

--- a/data/101/816/407/101816407.geojson
+++ b/data/101/816/407/101816407.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Lub\u0101na"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a09617acb847586b1d809198328f523",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101816407,
-    "wof:lastmodified":1566599054,
+    "wof:lastmodified":1582313196,
     "wof:name":"Lub\u0101na",
     "wof:parent_id":85686131,
     "wof:placetype":"locality",

--- a/data/101/816/409/101816409.geojson
+++ b/data/101/816/409/101816409.geojson
@@ -186,6 +186,9 @@
         "wk:page":"Sigulda"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9fbbe2105e3dce1aacd3f7bc6be87187",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599053,
+    "wof:lastmodified":1582313196,
     "wof:name":"Sigulda",
     "wof:parent_id":85686135,
     "wof:placetype":"locality",

--- a/data/101/816/411/101816411.geojson
+++ b/data/101/816/411/101816411.geojson
@@ -173,6 +173,9 @@
         "wk:page":"K\u0101rsava Municipality"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d34472f3a444743248d91cb91d36553e",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
         }
     ],
     "wof:id":101816411,
-    "wof:lastmodified":1566599058,
+    "wof:lastmodified":1582313196,
     "wof:name":"K\u0101rsava",
     "wof:parent_id":85686139,
     "wof:placetype":"locality",

--- a/data/101/816/413/101816413.geojson
+++ b/data/101/816/413/101816413.geojson
@@ -167,6 +167,9 @@
         "wk:page":"Madona"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c46021ec0543db09cbcf83c76e399e0",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":101816413,
-    "wof:lastmodified":1566599052,
+    "wof:lastmodified":1582313195,
     "wof:name":"Madona",
     "wof:parent_id":85686143,
     "wof:placetype":"locality",

--- a/data/101/816/417/101816417.geojson
+++ b/data/101/816/417/101816417.geojson
@@ -156,6 +156,9 @@
         "wk:page":"Cesvaine"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f877cf2d19fff97efa0cc133aaa104f",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Cesvaine",
     "wof:parent_id":85686151,
     "wof:placetype":"locality",

--- a/data/101/816/419/101816419.geojson
+++ b/data/101/816/419/101816419.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Valdem\u0101rpils"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ee5657f2d0dda2cdbe8ff7e8d25bd4e",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101816419,
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Valdem\u0101rpils",
     "wof:parent_id":85686157,
     "wof:placetype":"locality",

--- a/data/101/816/421/101816421.geojson
+++ b/data/101/816/421/101816421.geojson
@@ -176,6 +176,9 @@
         "wk:page":"Talsi"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cb6c48002419b8a5789855183e60929f",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":101816421,
-    "wof:lastmodified":1566599057,
+    "wof:lastmodified":1582313196,
     "wof:name":"Talsi",
     "wof:parent_id":85686157,
     "wof:placetype":"locality",

--- a/data/101/816/423/101816423.geojson
+++ b/data/101/816/423/101816423.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Stende"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e53bd378c9325ebc2db9d690aa242644",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101816423,
-    "wof:lastmodified":1566599052,
+    "wof:lastmodified":1582313195,
     "wof:name":"Stende",
     "wof:parent_id":85686157,
     "wof:placetype":"locality",

--- a/data/101/816/425/101816425.geojson
+++ b/data/101/816/425/101816425.geojson
@@ -74,6 +74,9 @@
         "wd:id":"Q15220126"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fd3f7d8533dc85cdbe10bb77468f1839",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":101816425,
-    "wof:lastmodified":1566599052,
+    "wof:lastmodified":1582313195,
     "wof:name":"Zvejniekciems",
     "wof:parent_id":85686169,
     "wof:placetype":"locality",

--- a/data/101/816/427/101816427.geojson
+++ b/data/101/816/427/101816427.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Saulkrasti"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a5cbf8d280aa70845f90d5f391ff89f",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101816427,
-    "wof:lastmodified":1566599058,
+    "wof:lastmodified":1582313197,
     "wof:name":"Saulkrasti",
     "wof:parent_id":85686169,
     "wof:placetype":"locality",

--- a/data/101/816/429/101816429.geojson
+++ b/data/101/816/429/101816429.geojson
@@ -203,6 +203,9 @@
         "wk:page":"C\u0113sis"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cb2b72e1879ffee7a8f9f1d1fbefba9",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":101816429,
-    "wof:lastmodified":1566599058,
+    "wof:lastmodified":1582313197,
     "wof:name":"C\u0113sis",
     "wof:parent_id":85686193,
     "wof:placetype":"locality",

--- a/data/101/816/435/101816435.geojson
+++ b/data/101/816/435/101816435.geojson
@@ -143,6 +143,9 @@
         "wk:page":"Piltene"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d5d941eb41dbc4c6cbb11d1530542f9",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101816435,
-    "wof:lastmodified":1566599060,
+    "wof:lastmodified":1582313197,
     "wof:name":"Piltene",
     "wof:parent_id":85686197,
     "wof:placetype":"locality",

--- a/data/101/816/437/101816437.geojson
+++ b/data/101/816/437/101816437.geojson
@@ -109,6 +109,9 @@
         "wd:id":"Q1023753"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf28a887796e574e724ef900dacb7697",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":101816437,
-    "wof:lastmodified":1566599053,
+    "wof:lastmodified":1582313196,
     "wof:name":"Roja",
     "wof:parent_id":85686211,
     "wof:placetype":"locality",

--- a/data/101/816/439/101816439.geojson
+++ b/data/101/816/439/101816439.geojson
@@ -200,6 +200,9 @@
         "wk:page":"Kolka, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c373565dd6bbdf616483073b455e581c",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":101816439,
-    "wof:lastmodified":1566599053,
+    "wof:lastmodified":1582313196,
     "wof:name":"Kolka",
     "wof:parent_id":85686221,
     "wof:placetype":"locality",

--- a/data/101/816/445/101816445.geojson
+++ b/data/101/816/445/101816445.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Balvi"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e7417a26b72f5e6ec12cbb35003403f4",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
         }
     ],
     "wof:id":101816445,
-    "wof:lastmodified":1566599058,
+    "wof:lastmodified":1582313197,
     "wof:name":"Balvi",
     "wof:parent_id":85686235,
     "wof:placetype":"locality",

--- a/data/101/816/447/101816447.geojson
+++ b/data/101/816/447/101816447.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Gulbene"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"245c2aa795fbe7f7578f1a01248701b0",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101816447,
-    "wof:lastmodified":1566599051,
+    "wof:lastmodified":1582313195,
     "wof:name":"Gulbene",
     "wof:parent_id":85686241,
     "wof:placetype":"locality",

--- a/data/101/816/449/101816449.geojson
+++ b/data/101/816/449/101816449.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Valmiera"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"271a85c50c5842e7021e39fb50be2a7f",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599052,
+    "wof:lastmodified":1582313195,
     "wof:name":"Valmiera",
     "wof:parent_id":85686243,
     "wof:placetype":"locality",

--- a/data/101/816/453/101816453.geojson
+++ b/data/101/816/453/101816453.geojson
@@ -144,6 +144,9 @@
         "qs_pg:id":124625
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b39f5942a3c14986d3b65f30a7be2f2",
     "wof:hierarchy":[
         {
@@ -154,7 +157,7 @@
         }
     ],
     "wof:id":101816453,
-    "wof:lastmodified":1566599054,
+    "wof:lastmodified":1582313196,
     "wof:name":"Smiltene",
     "wof:parent_id":85686249,
     "wof:placetype":"locality",

--- a/data/101/816/457/101816457.geojson
+++ b/data/101/816/457/101816457.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Limba\u017ei"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86ef8de25ba8c69f2d58c38f8ceb0694",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101816457,
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Limba\u017ei",
     "wof:parent_id":85686265,
     "wof:placetype":"locality",

--- a/data/101/816/459/101816459.geojson
+++ b/data/101/816/459/101816459.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Ape, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23fcae4ad360bb7b75d9044c3ee6a120",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":101816459,
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Ape",
     "wof:parent_id":85686269,
     "wof:placetype":"locality",

--- a/data/101/816/461/101816461.geojson
+++ b/data/101/816/461/101816461.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Seda, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c02a50097a43638f7613d940d614636",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101816461,
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Seda",
     "wof:parent_id":85686275,
     "wof:placetype":"locality",

--- a/data/101/816/463/101816463.geojson
+++ b/data/101/816/463/101816463.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Stren\u010di"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d6ff9380af86a41eed32fd5c34a8a9b",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":101816463,
-    "wof:lastmodified":1566599053,
+    "wof:lastmodified":1582313196,
     "wof:name":"Stren\u010di",
     "wof:parent_id":85686275,
     "wof:placetype":"locality",

--- a/data/101/816/465/101816465.geojson
+++ b/data/101/816/465/101816465.geojson
@@ -177,6 +177,9 @@
         "wd:id":"Q291333"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"021db6ce0a58edad4a09b49df370298f",
     "wof:hierarchy":[
         {
@@ -187,7 +190,7 @@
         }
     ],
     "wof:id":101816465,
-    "wof:lastmodified":1566599054,
+    "wof:lastmodified":1582313196,
     "wof:name":"Al\u016bksne",
     "wof:parent_id":85686279,
     "wof:placetype":"locality",

--- a/data/101/816/467/101816467.geojson
+++ b/data/101/816/467/101816467.geojson
@@ -159,6 +159,9 @@
         "wk:page":"Aina\u017ei"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df7ea495628c0276430027223c1fee68",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":101816467,
-    "wof:lastmodified":1566599059,
+    "wof:lastmodified":1582313197,
     "wof:name":"Aina\u017ei",
     "wof:parent_id":85686287,
     "wof:placetype":"locality",

--- a/data/101/816/471/101816471.geojson
+++ b/data/101/816/471/101816471.geojson
@@ -166,6 +166,9 @@
         "wk:page":"Aloja, Latvia"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a84557d92c7c792ad9fe37d183ca7508",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599052,
+    "wof:lastmodified":1582313195,
     "wof:name":"Aloja",
     "wof:parent_id":85686293,
     "wof:placetype":"locality",

--- a/data/101/816/475/101816475.geojson
+++ b/data/101/816/475/101816475.geojson
@@ -147,6 +147,9 @@
         "wk:page":"R\u016bjiena"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03c52506bf5e12371507e412a59e0bc3",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":101816475,
-    "wof:lastmodified":1566599058,
+    "wof:lastmodified":1582313196,
     "wof:name":"R\u016bjiena",
     "wof:parent_id":85686305,
     "wof:placetype":"locality",

--- a/data/101/817/309/101817309.geojson
+++ b/data/101/817/309/101817309.geojson
@@ -137,6 +137,9 @@
         "wd:id":"Q249715"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58b00841917c283f3eb804f1ec01b3f3",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101817309,
-    "wof:lastmodified":1566599062,
+    "wof:lastmodified":1582313197,
     "wof:name":"Olaine",
     "wof:parent_id":85685981,
     "wof:placetype":"locality",

--- a/data/101/839/839/101839839.geojson
+++ b/data/101/839/839/101839839.geojson
@@ -104,6 +104,9 @@
         "wk:page":"Bab\u012bte Municipality"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa29b540366d79017f0d8a75ffcf58ff",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101839839,
-    "wof:lastmodified":1566599071,
+    "wof:lastmodified":1582313199,
     "wof:name":"Bab\u012bte",
     "wof:parent_id":85686027,
     "wof:placetype":"locality",

--- a/data/101/839/841/101839841.geojson
+++ b/data/101/839/841/101839841.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Pi\u0146\u0137i"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21cf54a7c3af3f9781c0f0da030cf393",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101839841,
-    "wof:lastmodified":1566599071,
+    "wof:lastmodified":1582313199,
     "wof:name":"Pi\u0146\u0137i",
     "wof:parent_id":85686027,
     "wof:placetype":"locality",

--- a/data/101/839/843/101839843.geojson
+++ b/data/101/839/843/101839843.geojson
@@ -192,6 +192,9 @@
         "wk:page":"Valka"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef59882daea0ab5db52eba353c252ec6",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":101839843,
-    "wof:lastmodified":1566599071,
+    "wof:lastmodified":1582313199,
     "wof:name":"Valka",
     "wof:parent_id":85686295,
     "wof:placetype":"locality",

--- a/data/101/847/099/101847099.geojson
+++ b/data/101/847/099/101847099.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Grobi\u0146a"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4170758e604908ad601a99562196fe52",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101847099,
-    "wof:lastmodified":1566599067,
+    "wof:lastmodified":1582313198,
     "wof:name":"Grobi\u0146a",
     "wof:parent_id":85685811,
     "wof:placetype":"locality",

--- a/data/101/847/115/101847115.geojson
+++ b/data/101/847/115/101847115.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Broc\u0113ni"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"108af3383d98357bff690ed56befe0ed",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101847115,
-    "wof:lastmodified":1561839445,
+    "wof:lastmodified":1582313198,
     "wof:name":"Broc\u0113ni",
     "wof:parent_id":85685885,
     "wof:placetype":"locality",

--- a/data/101/847/117/101847117.geojson
+++ b/data/101/847/117/101847117.geojson
@@ -134,6 +134,9 @@
         "wk:page":"P\u0101vilosta"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b34ee54a192e07910c1d3cf4089298a8",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101847117,
-    "wof:lastmodified":1566599068,
+    "wof:lastmodified":1582313198,
     "wof:name":"P\u0101vilosta",
     "wof:parent_id":85685901,
     "wof:placetype":"locality",

--- a/data/101/847/119/101847119.geojson
+++ b/data/101/847/119/101847119.geojson
@@ -271,6 +271,9 @@
         "wk:page":"J\u0113kabpils"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e47a716d065c350d89ff5759c7e6aebb",
     "wof:hierarchy":[
         {
@@ -281,7 +284,7 @@
         }
     ],
     "wof:id":101847119,
-    "wof:lastmodified":1566599068,
+    "wof:lastmodified":1582313198,
     "wof:name":"J\u0113kabpils",
     "wof:parent_id":85685911,
     "wof:placetype":"locality",

--- a/data/101/847/135/101847135.geojson
+++ b/data/101/847/135/101847135.geojson
@@ -107,6 +107,9 @@
         "wd:id":"Q344608"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89e11eefd1063d225bc5164b7dcb897d",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":101847135,
-    "wof:lastmodified":1566599066,
+    "wof:lastmodified":1582313198,
     "wof:name":"\u0136ekava",
     "wof:parent_id":85685999,
     "wof:placetype":"locality",

--- a/data/101/847/137/101847137.geojson
+++ b/data/101/847/137/101847137.geojson
@@ -80,6 +80,9 @@
         "wd:id":"Q4539646"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e297778753b76e93d3879641bfa71e31",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":101847137,
-    "wof:lastmodified":1566599070,
+    "wof:lastmodified":1582313198,
     "wof:name":"Jaunm\u0101rupe",
     "wof:parent_id":85686007,
     "wof:placetype":"locality",

--- a/data/101/847/139/101847139.geojson
+++ b/data/101/847/139/101847139.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q15219556"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d657f82167ee592441f449a47b77dc4a",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":101847139,
-    "wof:lastmodified":1566599069,
+    "wof:lastmodified":1582313198,
     "wof:name":"Priedaine",
     "wof:parent_id":85686043,
     "wof:placetype":"locality",

--- a/data/101/847/155/101847155.geojson
+++ b/data/101/847/155/101847155.geojson
@@ -75,6 +75,9 @@
         "wd:id":"Q15219226"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b087de62b428272e4338c2ce56be045",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":101847155,
-    "wof:lastmodified":1566599069,
+    "wof:lastmodified":1582313198,
     "wof:name":"Lapme\u017eciems",
     "wof:parent_id":85686103,
     "wof:placetype":"locality",

--- a/data/101/847/161/101847161.geojson
+++ b/data/101/847/161/101847161.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Vanga\u017ei"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a50fcd358350c621073b7af2beb42f89",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599066,
+    "wof:lastmodified":1582313198,
     "wof:name":"Vanga\u017ei",
     "wof:parent_id":85686117,
     "wof:placetype":"locality",

--- a/data/101/847/163/101847163.geojson
+++ b/data/101/847/163/101847163.geojson
@@ -95,6 +95,9 @@
         "wk:page":"M\u0113rsrags"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3949ba8405d4b3967782ec3eec35878c",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101847163,
-    "wof:lastmodified":1566599069,
+    "wof:lastmodified":1582313198,
     "wof:name":"M\u0113rsrags",
     "wof:parent_id":85686125,
     "wof:placetype":"locality",

--- a/data/101/847/165/101847165.geojson
+++ b/data/101/847/165/101847165.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q853761"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03e4e2fb8742041b58d78fd6e4804eee",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101847165,
-    "wof:lastmodified":1566599069,
+    "wof:lastmodified":1582313198,
     "wof:name":"L\u012bgatne",
     "wof:parent_id":85686153,
     "wof:placetype":"locality",

--- a/data/101/847/167/101847167.geojson
+++ b/data/101/847/167/101847167.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Sabile"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3467fb72f0a83f45b624211dfcfa012e",
     "wof:hierarchy":[
         {
@@ -147,7 +150,7 @@
         }
     ],
     "wof:id":101847167,
-    "wof:lastmodified":1566599066,
+    "wof:lastmodified":1582313198,
     "wof:name":"Sabile",
     "wof:parent_id":85686157,
     "wof:placetype":"locality",

--- a/data/101/847/173/101847173.geojson
+++ b/data/101/847/173/101847173.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Rauna"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98fb16f59cf3497916f1117e410f8002",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101847173,
-    "wof:lastmodified":1566599067,
+    "wof:lastmodified":1582313198,
     "wof:name":"Rauna",
     "wof:parent_id":85686225,
     "wof:placetype":"locality",

--- a/data/101/847/179/101847179.geojson
+++ b/data/101/847/179/101847179.geojson
@@ -140,6 +140,9 @@
         "wk:page":"Salacgr\u012bva"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0de5204f13ad56413b5f723f6e69d750",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101847179,
-    "wof:lastmodified":1566599070,
+    "wof:lastmodified":1582313198,
     "wof:name":"Salacgr\u012bva",
     "wof:parent_id":85686287,
     "wof:placetype":"locality",

--- a/data/101/847/181/101847181.geojson
+++ b/data/101/847/181/101847181.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Staicele"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6845760c344f839da0f391e792023565",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566599068,
+    "wof:lastmodified":1582313198,
     "wof:name":"Staicele",
     "wof:parent_id":85686293,
     "wof:placetype":"locality",

--- a/data/101/872/913/101872913.geojson
+++ b/data/101/872/913/101872913.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Lociki"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69c6ae075f4b48d2d202f621adec9cef",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":101872913,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Lociki",
     "wof:parent_id":85685825,
     "wof:placetype":"locality",

--- a/data/101/872/915/101872915.geojson
+++ b/data/101/872/915/101872915.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q5734017"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c0242794fc82738ebef27261621c151",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":101872915,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Kalk\u016bni",
     "wof:parent_id":85685825,
     "wof:placetype":"locality",

--- a/data/101/872/919/101872919.geojson
+++ b/data/101/872/919/101872919.geojson
@@ -58,6 +58,9 @@
         "wd:id":"Q15218618"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8cdfe2d9037b54aaf7952eef5a6da2e",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":101872919,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"Avoti",
     "wof:parent_id":85685957,
     "wof:placetype":"locality",

--- a/data/101/872/921/101872921.geojson
+++ b/data/101/872/921/101872921.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q15219441"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72a81bb6d42e1ddd3d911f978214b00a",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101872921,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"N\u0101kotne",
     "wof:parent_id":85685971,
     "wof:placetype":"locality",

--- a/data/101/872/923/101872923.geojson
+++ b/data/101/872/923/101872923.geojson
@@ -54,6 +54,10 @@
         "qs_pg:id":1035032
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce5942e4409412c233e03bef7cc713b5",
     "wof:hierarchy":[
         {
@@ -64,7 +68,7 @@
         }
     ],
     "wof:id":101872923,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Jaunolaine",
     "wof:parent_id":85685981,
     "wof:placetype":"locality",

--- a/data/101/872/925/101872925.geojson
+++ b/data/101/872/925/101872925.geojson
@@ -71,6 +71,9 @@
         "wd:id":"Q4102737"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4ce6e024fb7e4b277176d4d1622e4b8",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":101872925,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Valdlau\u010di",
     "wof:parent_id":85685999,
     "wof:placetype":"locality",

--- a/data/101/872/927/101872927.geojson
+++ b/data/101/872/927/101872927.geojson
@@ -84,6 +84,9 @@
         "wk:page":"M\u0101rupe"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"edc22d57f4d2595f800145d7987dbebe",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":101872927,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"M\u0101rupe",
     "wof:parent_id":85686007,
     "wof:placetype":"locality",

--- a/data/101/872/929/101872929.geojson
+++ b/data/101/872/929/101872929.geojson
@@ -76,6 +76,10 @@
         "wd:id":"Q14917203"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d1f0a6daad27aac242358fef754d4df",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
         }
     ],
     "wof:id":101872929,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313197,
     "wof:name":"T\u012braine",
     "wof:parent_id":85686007,
     "wof:placetype":"locality",

--- a/data/101/872/931/101872931.geojson
+++ b/data/101/872/931/101872931.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q15218686"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3dccc2a157b4dca1f1d3d304eca87e16",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":101872931,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Birzgale",
     "wof:parent_id":85686011,
     "wof:placetype":"locality",

--- a/data/101/872/933/101872933.geojson
+++ b/data/101/872/933/101872933.geojson
@@ -142,6 +142,10 @@
         "qs_pg:id":1088687
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a4eb6eac4bf96bbe9e82bf642976d06",
     "wof:hierarchy":[
         {
@@ -152,7 +156,7 @@
         }
     ],
     "wof:id":101872933,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313197,
     "wof:name":"Koknese",
     "wof:parent_id":85686023,
     "wof:placetype":"locality",

--- a/data/101/872/937/101872937.geojson
+++ b/data/101/872/937/101872937.geojson
@@ -74,6 +74,9 @@
         "wk:page":"Upeslejas"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c3da3c6a5dd50ac39f575668ebc474a",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":101872937,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Upeslejas",
     "wof:parent_id":85686033,
     "wof:placetype":"locality",

--- a/data/101/872/939/101872939.geojson
+++ b/data/101/872/939/101872939.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Za\u0137umui\u017ea"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8334a67da2865b175a835d64863c26f6",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":101872939,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"Za\u0137umui\u017ea",
     "wof:parent_id":85686069,
     "wof:placetype":"locality",

--- a/data/101/872/941/101872941.geojson
+++ b/data/101/872/941/101872941.geojson
@@ -64,6 +64,9 @@
         "qs_pg:id":2
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"035ce7ac756cb3f1d9e57749984d8b54",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":101872941,
-    "wof:lastmodified":1566599063,
+    "wof:lastmodified":1582313197,
     "wof:name":"J\u0101\u0146mui\u017ea",
     "wof:parent_id":85686229,
     "wof:placetype":"locality",

--- a/data/101/875/035/101875035.geojson
+++ b/data/101/875/035/101875035.geojson
@@ -58,6 +58,9 @@
         "wd:id":"Q15219018"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4b9168627208a49da365067bdd277c6",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":101875035,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"Jauncode",
     "wof:parent_id":85685851,
     "wof:placetype":"locality",

--- a/data/101/875/037/101875037.geojson
+++ b/data/101/875/037/101875037.geojson
@@ -147,6 +147,9 @@
         "wd:id":"Q15219509"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebb40cd0f817c8b6ba32506a68c074fb",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":101875037,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"Peltes",
     "wof:parent_id":85686135,
     "wof:placetype":"locality",

--- a/data/101/875/039/101875039.geojson
+++ b/data/101/875/039/101875039.geojson
@@ -66,6 +66,10 @@
         "wd:id":"Q15219963"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef9893aabd09d7b5f1d1221ee6cc85aa",
     "wof:hierarchy":[
         {
@@ -76,7 +80,7 @@
         }
     ],
     "wof:id":101875039,
-    "wof:lastmodified":1566599064,
+    "wof:lastmodified":1582313198,
     "wof:name":"Valmiermui\u017ea",
     "wof:parent_id":85686283,
     "wof:placetype":"locality",

--- a/data/101/911/331/101911331.geojson
+++ b/data/101/911/331/101911331.geojson
@@ -60,6 +60,9 @@
         "wd:id":"Q15218613"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"01fcb367b73bac84429f3750f5bff591",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101911331,
-    "wof:lastmodified":1566599071,
+    "wof:lastmodified":1582313199,
     "wof:name":"Aug\u0161l\u012bgatne",
     "wof:parent_id":85686153,
     "wof:placetype":"locality",

--- a/data/101/911/719/101911719.geojson
+++ b/data/101/911/719/101911719.geojson
@@ -91,6 +91,9 @@
         "wk:page":"\u0136emeri"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25b9db4000b82d94bf8568b16a84a8cb",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101911719,
-    "wof:lastmodified":1566599071,
+    "wof:lastmodified":1582313199,
     "wof:name":"\u0136emeri",
     "wof:parent_id":85686031,
     "wof:placetype":"locality",

--- a/data/101/911/721/101911721.geojson
+++ b/data/101/911/721/101911721.geojson
@@ -69,6 +69,9 @@
         "wk:page":"Ber\u0123i"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f662da65c30cada75d4932e6a6de5328",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":101911721,
-    "wof:lastmodified":1566599071,
+    "wof:lastmodified":1582313199,
     "wof:name":"Ber\u0123i",
     "wof:parent_id":85686065,
     "wof:placetype":"locality",

--- a/data/101/913/043/101913043.geojson
+++ b/data/101/913/043/101913043.geojson
@@ -109,6 +109,9 @@
         "wd:id":"Q372999"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80d570a2f293d46bf523d96f4a759bf2",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":101913043,
-    "wof:lastmodified":1561839444,
+    "wof:lastmodified":1582313198,
     "wof:name":"Aglona",
     "wof:parent_id":85685855,
     "wof:placetype":"locality",

--- a/data/856/332/79/85633279.geojson
+++ b/data/856/332/79/85633279.geojson
@@ -1040,6 +1040,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "quattroshapes",
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1095,6 +1096,11 @@
     },
     "wof:country":"LV",
     "wof:country_alpha3":"LVA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"1f5747d8b25f7dd81b82ee265e970254",
     "wof:hierarchy":[
         {
@@ -1109,7 +1115,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1566598823,
+    "wof:lastmodified":1582313192,
     "wof:name":"Latvia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/332/79/85633279.geojson
+++ b/data/856/332/79/85633279.geojson
@@ -1040,7 +1040,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "quattroshapes",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1115,7 +1114,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1582313192,
+    "wof:lastmodified":1583199979,
     "wof:name":"Latvia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/015/13/85901513.geojson
+++ b/data/859/015/13/85901513.geojson
@@ -104,6 +104,9 @@
         "wd:id":"Q2632576"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"90a08d3db23ea0f513874a0d3bbe7eba",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Agenskalns",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/15/85901515.geojson
+++ b/data/859/015/15/85901515.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Andrejsala"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74900c804dbf7a170e5557ee00ffb96c",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Andrejsala",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/19/85901519.geojson
+++ b/data/859/015/19/85901519.geojson
@@ -84,6 +84,10 @@
         "qs_pg:id":1066275
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4257c5d2d7841e6f970e20871c568661",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Podrags",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/21/85901521.geojson
+++ b/data/859/015/21/85901521.geojson
@@ -92,6 +92,10 @@
         "wd:id":"Q1986090"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9f02b578d4dba6f15d3780d2d994f9b",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Bulduri",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/23/85901523.geojson
+++ b/data/859/015/23/85901523.geojson
@@ -94,6 +94,10 @@
         "wd:id":"Q2033866"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"24a245a94011bfb86a42060eb3fcd8f4",
     "wof:hierarchy":[
         {
@@ -108,7 +112,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Dubulti",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/25/85901525.geojson
+++ b/data/859/015/25/85901525.geojson
@@ -100,6 +100,10 @@
         "wk:page":"Dzintari"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"40b768f53b2c76bcc728fbe4b156d026",
     "wof:hierarchy":[
         {
@@ -114,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Dzintari",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/27/85901527.geojson
+++ b/data/859/015/27/85901527.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1088606
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"468bf48a722e350b39d2df178bb3f975",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Ilgeciems",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/29/85901529.geojson
+++ b/data/859/015/29/85901529.geojson
@@ -93,6 +93,10 @@
         "wk:page":"Jaundubulti"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85206a2b0136c80cc059246b464071bf",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Jaundubulti",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/31/85901531.geojson
+++ b/data/859/015/31/85901531.geojson
@@ -86,6 +86,9 @@
         "gp:id":852765
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c55a9301e8e4e99b5688d21892e7dd4a",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Jaunmilgravis",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/33/85901533.geojson
+++ b/data/859/015/33/85901533.geojson
@@ -90,6 +90,10 @@
         "qs_pg:id":1083362
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"faaba3e27165d32f30f8d710be555472",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Jugla",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/37/85901537.geojson
+++ b/data/859/015/37/85901537.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1167447
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b3b176b8649851240f8a423415253ea7",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Kauguri",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/39/85901539.geojson
+++ b/data/859/015/39/85901539.geojson
@@ -97,6 +97,10 @@
         "wk:page":"Majori"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"39023f209101a354e01da99c4eb6bca7",
     "wof:hierarchy":[
         {
@@ -111,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Majori",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/41/85901541.geojson
+++ b/data/859/015/41/85901541.geojson
@@ -96,6 +96,10 @@
         "wk:page":"Mellu\u017ei"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"79c765ef35e7a8bfda99fd53f93147b4",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Mellu\u017ei",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/43/85901543.geojson
+++ b/data/859/015/43/85901543.geojson
@@ -86,6 +86,10 @@
         "qs_pg:id":1157439
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"07f63753f7adb068ba9eb77dfa375d89",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"R\u012bgas J\u016brmala",
     "wof:parent_id":101751787,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/45/85901545.geojson
+++ b/data/859/015/45/85901545.geojson
@@ -101,6 +101,10 @@
         "wk:page":"Tor\u0146akalns"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16491da517742ef589d26c3b24ca6ebc",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598797,
+    "wof:lastmodified":1582313190,
     "wof:name":"Tornakalns",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/015/47/85901547.geojson
+++ b/data/859/015/47/85901547.geojson
@@ -116,6 +116,10 @@
         "wk:page":"Vecm\u012blgr\u0101vis"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"589b88588819b8b42ad20e2672598e8a",
     "wof:hierarchy":[
         {
@@ -130,7 +134,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Vecmilgravis",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/83/85907783.geojson
+++ b/data/859/077/83/85907783.geojson
@@ -100,6 +100,10 @@
         "wd:id":"Q4269916"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"209c94ea2f32c86716d647cad0c8dd97",
     "wof:hierarchy":[
         {
@@ -114,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Lucavsala",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/85/85907785.geojson
+++ b/data/859/077/85/85907785.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":15086
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0c3c01126fbc3245db58bec6ed500acb",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Kazas Seklis",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/87/85907787.geojson
+++ b/data/859/077/87/85907787.geojson
@@ -89,6 +89,10 @@
         "wd:id":"Q2085553"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b9a91afcf41170e5e5bed79ee111194c",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Bisumuiza",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/89/85907789.geojson
+++ b/data/859/077/89/85907789.geojson
@@ -89,6 +89,10 @@
         "wd:id":"Q1978424"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"653c9a199efe9a53409dd58f0b6ce66d",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Ziepniekkalns",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/91/85907791.geojson
+++ b/data/859/077/91/85907791.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":368072
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"93ae3084135e632aed5ef18928c8f47d",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Ozolciems",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/93/85907793.geojson
+++ b/data/859/077/93/85907793.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":976699
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa809ca748d0d70e22d47227a4282172",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Kengarags",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/95/85907795.geojson
+++ b/data/859/077/95/85907795.geojson
@@ -87,6 +87,9 @@
         "wd:id":"Q3625542"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"558f22684b2e36d1f469e31f36d02fea",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598798,
+    "wof:lastmodified":1582313190,
     "wof:name":"Darzciems",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/077/97/85907797.geojson
+++ b/data/859/077/97/85907797.geojson
@@ -104,6 +104,10 @@
         "wd:id":"Q1388229"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02b37de125a0584419dcf67ad6b026ab",
     "wof:hierarchy":[
         {
@@ -118,7 +122,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Maskavas Forstate",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/01/85907801.geojson
+++ b/data/859/078/01/85907801.geojson
@@ -163,6 +163,10 @@
         "wk:page":"Vecr\u012bga"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"75a46573b8e9bbd4125ff22b30c0e24b",
     "wof:hierarchy":[
         {
@@ -177,7 +181,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1568233169,
+    "wof:lastmodified":1582313191,
     "wof:name":"Vecriga",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/03/85907803.geojson
+++ b/data/859/078/03/85907803.geojson
@@ -96,6 +96,10 @@
         "wd:id":"Q4993616"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38ee436ec3f0149bf1c878e49c387193",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Dzirciems",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/05/85907805.geojson
+++ b/data/859/078/05/85907805.geojson
@@ -91,6 +91,10 @@
         "qs_pg:id":1263320
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"047661d3a9cd05a888973ca5f27dcce9",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Kipsala",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/07/85907807.geojson
+++ b/data/859/078/07/85907807.geojson
@@ -83,6 +83,10 @@
         "wd:id":"Q1986080"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"877368e53f13a19f1a1e5fdd65c84e2e",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Zasulauks",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/09/85907809.geojson
+++ b/data/859/078/09/85907809.geojson
@@ -86,6 +86,10 @@
         "wd:id":"Q4992826"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c33b0f2de8c13c039993a6e7c57123f",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Pleskodale",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/11/85907811.geojson
+++ b/data/859/078/11/85907811.geojson
@@ -95,6 +95,10 @@
         "wk:page":"Zolit\u016bde"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f6fb33e00a66cef2e3ff0e992b174ef",
     "wof:hierarchy":[
         {
@@ -109,7 +113,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313190,
     "wof:name":"Zolitude",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/13/85907813.geojson
+++ b/data/859/078/13/85907813.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1087799
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"563741e5711b7f188e190adc25d21b35",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598801,
+    "wof:lastmodified":1582313191,
     "wof:name":"Petersala",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/15/85907815.geojson
+++ b/data/859/078/15/85907815.geojson
@@ -83,6 +83,10 @@
         "wd:id":"Q1974349"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d09844728f96baf0b43e1a862db50c5b",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598801,
+    "wof:lastmodified":1582313191,
     "wof:name":"Purvciems",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/19/85907819.geojson
+++ b/data/859/078/19/85907819.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":485195
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"69941cb3bd4a8e8fae59396d3f30ecc6",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Teika",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/21/85907821.geojson
+++ b/data/859/078/21/85907821.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1330375
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"99b505d9039ad544e81785d693df7276",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Aplokciems",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/23/85907823.geojson
+++ b/data/859/078/23/85907823.geojson
@@ -86,6 +86,10 @@
         "qs_pg:id":1087800
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b1916638637e80912eb1cf51527a6a0",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598801,
+    "wof:lastmodified":1582313191,
     "wof:name":"Sarkandaugava",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/25/85907825.geojson
+++ b/data/859/078/25/85907825.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":485196
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"04f179b69c55b9f7c1178a38ccbf6df4",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598801,
+    "wof:lastmodified":1582313191,
     "wof:name":"Vejzaksala",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/27/85907827.geojson
+++ b/data/859/078/27/85907827.geojson
@@ -113,6 +113,10 @@
         "wd:id":"Q2595448"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b7efc3ce4ffdd20d409b75ef9216dc2",
     "wof:hierarchy":[
         {
@@ -127,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313190,
     "wof:name":"Zakusala",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/29/85907829.geojson
+++ b/data/859/078/29/85907829.geojson
@@ -86,6 +86,10 @@
         "wd:id":"Q4149523"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"732a9d5faacf964ae6b403b0fffe4560",
     "wof:hierarchy":[
         {
@@ -100,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Grizinkalns",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/31/85907831.geojson
+++ b/data/859/078/31/85907831.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1181833
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9dc6a3a281b9af2ccf335b4707c56aef",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Pilsetas",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/33/85907833.geojson
+++ b/data/859/078/33/85907833.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1236460
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"372034276cf8d44bc2bb6873da6abb33",
     "wof:hierarchy":[
         {
@@ -82,7 +86,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598799,
+    "wof:lastmodified":1582313190,
     "wof:name":"Ganibas",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/37/85907837.geojson
+++ b/data/859/078/37/85907837.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":350651
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7e819da10b90164e388e548f65f8a53",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598800,
+    "wof:lastmodified":1582313191,
     "wof:name":"Nordeki",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",

--- a/data/859/078/39/85907839.geojson
+++ b/data/859/078/39/85907839.geojson
@@ -101,6 +101,10 @@
         "wk:page":"Imanta"
     },
     "wof:country":"LV",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c04ff68531748964a09b5f2cff721ba9",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566598801,
+    "wof:lastmodified":1582313191,
     "wof:name":"Imanta",
     "wof:parent_id":101751789,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.