### PR TITLE
Remove `[city]` from preferred name of Jelgava

### DIFF
--- a/data/101/751/785/101751785.geojson
+++ b/data/101/751/785/101751785.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.003397,
     "geom:area_square_m":23093430.898466,
-    "geom:bbox":"23.652767,56.6184615,23.7780115,56.683056",
+    "geom:bbox":"23.65276699999981,56.6184614999998,23.77801149999988,56.68305599999985",
     "geom:latitude":56.649666,
     "geom:longitude":23.72389,
     "gn:population":61791,
@@ -82,7 +82,7 @@
         "\u0393\u03b9\u03ad\u03bb\u03b3\u03ba\u03b1\u03b2\u03b1"
     ],
     "name:eng_x_preferred":[
-        "Jelgava [City]"
+        "Jelgava"
     ],
     "name:eng_x_variant":[
         "Elgava",
@@ -429,7 +429,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1582313198,
+    "wof:lastmodified":1612380604,
     "wof:name":"Jelgava",
     "wof:parent_id":85685881,
     "wof:placetype":"locality",


### PR DESCRIPTION
As reported  by a Geocode Earth customer, the city of Jelgava had the string `[city]` in its English preferred name. I assume this came from somewhere hoping to distinguish it from the `region` its parented by.

Updating `data/101/751/785/101751785.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)