### PR TITLE
lv concordances, placetype local, and more

### DIFF
--- a/data/856/332/79/85633279.geojson
+++ b/data/856/332/79/85633279.geojson
@@ -1277,6 +1277,7 @@
         "hasc:id":"LV",
         "icao:code":"YL",
         "ioc:id":"LAT",
+        "iso:code":"LV",
         "itu:id":"LVA",
         "loc:id":"n80150219",
         "m49:code":"428",
@@ -1291,6 +1292,7 @@
         "wk:page":"Latvia",
         "wmo:id":"LV"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"LV",
     "wof:country_alpha3":"LVA",
     "wof:geom_alt":[
@@ -1312,7 +1314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1694492263,
+    "wof:lastmodified":1695881376,
     "wof:name":"Latvia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/332/79/85633279.geojson
+++ b/data/856/332/79/85633279.geojson
@@ -24,6 +24,9 @@
     "itu:country_code":[
         "371"
     ],
+    "label:eng_x_preferred_placetype":[
+        "country"
+    ],
     "label:eng_x_preferred_shortcode":[
         "LV"
     ],
@@ -1295,7 +1298,7 @@
         "naturalearth-display-terrestrial-zoom6",
         "naturalearth"
     ],
-    "wof:geomhash":"0fe520cc19e0a0298897c0706e12a256",
+    "wof:geomhash":"c14f37a97c6ac361fcf88f2737af1b48",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -1309,7 +1312,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938810,
+    "wof:lastmodified":1694492263,
     "wof:name":"Latvia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/857/89/85685789.geojson
+++ b/data/856/857/89/85685789.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628302,
         "gp:id":-2346029,
         "hasc:id":"LV.RC",
+        "iso:code":"LV-081",
         "iso:id":"LV-081",
+        "qs:local_id":"6485",
         "wd:id":"Q2124995"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"ed868b47434c1299dd2fd2a42cf130fa",
+    "wof:geomhash":"ba6a34d0bea86ef8bf721778c1a6cbd1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938795,
+    "wof:lastmodified":1695885327,
     "wof:name":"Rucavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/857/91/85685791.geojson
+++ b/data/856/857/91/85685791.geojson
@@ -299,11 +299,17 @@
         "gn:id":7628301,
         "gp:id":-2346029,
         "hasc:id":"LV.NI",
+        "iso:code":"LV-066",
         "iso:id":"LV-066",
+        "qs:local_id":"6479",
         "wd:id":"Q1950456"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"630e6cfd70e9e56b9fe3dad9d2311642",
+    "wof:geomhash":"1e8e211a94fd842962b9819e4e437095",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938795,
+    "wof:lastmodified":1695885327,
     "wof:name":"Nicas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/857/95/85685795.geojson
+++ b/data/856/857/95/85685795.geojson
@@ -396,11 +396,17 @@
         "eurostat:nuts_2021_id":"0050000",
         "fips:code":"LG06",
         "hasc:id":"LV.DV",
+        "iso:code":"LV-DGV",
         "iso:id":"LV-DGV",
+        "qs:local_id":"0500",
         "wd:id":"Q80021"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"a49797e740fdd28cf97bc35911d422a9",
+    "wof:geomhash":"7e90fdc214b76a0af682dcdf8068e2dd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -415,7 +421,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938795,
+    "wof:lastmodified":1695885328,
     "wof:name":"Daugavpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/857/99/85685799.geojson
+++ b/data/856/857/99/85685799.geojson
@@ -430,12 +430,18 @@
         "gn:id":457955,
         "gp:id":-20070118,
         "hasc:id":"LV.LJ",
+        "iso:code":"LV-LPX",
         "iso:id":"LV-LPX",
+        "qs:local_id":"1700",
         "unlc:id":"LV-LPX",
         "wd:id":"Q167668"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"162a5e37919d317410ce800b815e6bef",
+    "wof:geomhash":"8bfb0da5aadfc38688208d239419132d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -450,7 +456,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938796,
+    "wof:lastmodified":1695885328,
     "wof:name":"Liepaja",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/03/85685803.geojson
+++ b/data/856/858/03/85685803.geojson
@@ -301,11 +301,17 @@
         "gn:id":7628306,
         "gp:id":-2346029,
         "hasc:id":"LV.PK",
+        "iso:code":"LV-074",
         "iso:id":"LV-074",
+        "qs:local_id":"6416",
         "wd:id":"Q2304893"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"dd42ba9cb965ec99cdedeeddec6bf9d9",
+    "wof:geomhash":"4952d65282196806c4bb7883fb5621e7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -320,7 +326,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938803,
+    "wof:lastmodified":1695885328,
     "wof:name":"Priekules",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/07/85685807.geojson
+++ b/data/856/858/07/85685807.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628307,
         "gp:id":-2346029,
         "hasc:id":"LV.VD",
+        "iso:code":"LV-100",
         "iso:id":"LV-100",
+        "qs:local_id":"6493",
         "wd:id":"Q511151"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"2225b00faa6822c114bfa77db9b2748d",
+    "wof:geomhash":"6d4b20a5b9a2e47bad317a9246187346",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938807,
+    "wof:lastmodified":1695885328,
     "wof:name":"Vainodes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/11/85685811.geojson
+++ b/data/856/858/11/85685811.geojson
@@ -296,11 +296,17 @@
         "gn:id":7628303,
         "gp:id":-2346029,
         "hasc:id":"LV.GR",
+        "iso:code":"LV-032",
         "iso:id":"LV-032",
+        "qs:local_id":"6410",
         "wd:id":"Q2320320"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"baf97dabb1366023c375d982f89cd24d",
+    "wof:geomhash":"fd1afb5cb71e045c2b961ed63babba27",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938805,
+    "wof:lastmodified":1695885328,
     "wof:name":"Grobinas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/15/85685815.geojson
+++ b/data/856/858/15/85685815.geojson
@@ -292,11 +292,17 @@
         "gn:id":7628339,
         "gp:id":-2346042,
         "hasc:id":"LV.IL",
+        "iso:code":"LV-036",
         "iso:id":"LV-036",
+        "qs:local_id":"4408",
         "wd:id":"Q2025473"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"aa3d645f3235fbc2de50c01b3b2e172d",
+    "wof:geomhash":"c60bad01372eb9045f18e55c849cf233",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938808,
+    "wof:lastmodified":1695885328,
     "wof:name":"Ilukstes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/19/85685819.geojson
+++ b/data/856/858/19/85685819.geojson
@@ -301,11 +301,17 @@
         "gn:id":7628338,
         "gp:id":-2346026,
         "hasc:id":"LV.AN",
+        "iso:code":"LV-004",
         "iso:id":"LV-004",
+        "qs:local_id":"5608",
         "wd:id":"Q865658"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"c407eed6e9f5cc38cd9455ee338da984",
+    "wof:geomhash":"6af32abf999ff56bd02e670afe2d1a92",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -320,7 +326,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938806,
+    "wof:lastmodified":1695885328,
     "wof:name":"Aknistes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/25/85685825.geojson
+++ b/data/856/858/25/85685825.geojson
@@ -394,12 +394,18 @@
         "eurostat:nuts_2021_id":"0440200",
         "fips:code":"LG58",
         "hasc:id":"LV.DP",
+        "iso:code":"LV-025",
         "iso:id":"LV-025",
+        "qs:local_id":"4402",
         "unlc:id":"LV-025",
         "wd:id":"Q80021"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"187867a46651adf381a6fb108692915c",
+    "wof:geomhash":"7a876bb0a3c6144a62ad416572a3805e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -414,7 +420,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938809,
+    "wof:lastmodified":1695885328,
     "wof:name":"Daugavpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/29/85685829.geojson
+++ b/data/856/858/29/85685829.geojson
@@ -289,11 +289,17 @@
         "gn:id":7628304,
         "gp:id":-2346030,
         "hasc:id":"LV.DR",
+        "iso:code":"LV-028",
         "iso:id":"LV-028",
+        "qs:local_id":"6408",
         "wd:id":"Q1962356"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"d7add63ffc04f8fc0504992a90a0c9dc",
+    "wof:geomhash":"7f8aed94c96a07de31644579b4dac3e3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938805,
+    "wof:lastmodified":1695885328,
     "wof:name":"Durbes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/33/85685833.geojson
+++ b/data/856/858/33/85685833.geojson
@@ -291,11 +291,17 @@
         "gn:id":458621,
         "gp:id":-2346028,
         "hasc:id":"LV.KS",
+        "iso:code":"LV-047",
         "iso:id":"LV-047",
+        "qs:local_id":"6002",
         "wd:id":"Q1831695"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"63d49b2af259f1a38388e68d1a8a1e82",
+    "wof:geomhash":"cd4a22ccfef437536866b26689d302c6",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -310,7 +316,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938805,
+    "wof:lastmodified":1695885328,
     "wof:name":"Kraslavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/37/85685837.geojson
+++ b/data/856/858/37/85685837.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628315,
         "gp:id":-2346026,
         "hasc:id":"LV.TE",
+        "iso:code":"LV-098",
         "iso:id":"LV-098",
+        "qs:local_id":"4689",
         "wd:id":"Q2269685"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"b32bbed406b965a585c1db10352823d0",
+    "wof:geomhash":"aef930750832243851a8cfbc3b81844a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938807,
+    "wof:lastmodified":1695885328,
     "wof:name":"Tervetes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/39/85685839.geojson
+++ b/data/856/858/39/85685839.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628312,
         "gp:id":-2346026,
         "hasc:id":"LV.AU",
+        "iso:code":"LV-010",
         "iso:id":"LV-010",
+        "qs:local_id":"4608",
         "wd:id":"Q1934932"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"f91352d9c534483fa08bea9c28b65294",
+    "wof:geomhash":"e7f49c45ddc5c5fc0ab8430e305aa054",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938808,
+    "wof:lastmodified":1695885328,
     "wof:name":"Auces",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/45/85685845.geojson
+++ b/data/856/858/45/85685845.geojson
@@ -296,11 +296,17 @@
         "gn:id":7628317,
         "gp:id":-2346026,
         "hasc:id":"LV.RD",
+        "iso:code":"LV-083",
         "iso:id":"LV-083",
+        "qs:local_id":"4077",
         "wd:id":"Q2122124"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"d14a2b8efce39edc164a35c204b942ab",
+    "wof:geomhash":"e2a8d3d864e3b418191bc3bb1125e0a3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938806,
+    "wof:lastmodified":1695885328,
     "wof:name":"Rundales",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/51/85685851.geojson
+++ b/data/856/858/51/85685851.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":22442,
     "eurostat:population_year":2020,
     "geom:area":0.114457,
-    "geom:area_square_m":783285749.212996,
+    "geom:area_square_m":783285712.603974,
     "geom:bbox":"24.016603,56.244896,24.583802,56.549657",
     "geom:latitude":56.396255,
     "geom:longitude":24.284011,
@@ -279,11 +279,17 @@
         "gn:id":461112,
         "gp:id":-2346021,
         "hasc:id":"LV.BK",
+        "iso:code":"LV-016",
         "iso:id":"LV-016",
+        "qs:local_id":"4002",
         "wd:id":"Q2365998"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"84e67cc17816df7fa0c9a9eeb4e6edf0",
+    "wof:geomhash":"70c6ee0fb63ffe3aa5b10b74204dae90",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -298,7 +304,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938804,
+    "wof:lastmodified":1695885328,
     "wof:name":"Bauskas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/55/85685855.geojson
+++ b/data/856/858/55/85685855.geojson
@@ -310,11 +310,17 @@
         "gn:id":7628345,
         "gp:id":-2346042,
         "hasc:id":"LV.AG",
+        "iso:code":"LV-001",
         "iso:id":"LV-001",
+        "qs:local_id":"6043",
         "wd:id":"Q2045300"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e7a18a73f54a96e1f4b8ef65a494fbd3",
+    "wof:geomhash":"19d1130a1e6f8d1620350fb405ec2e43",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -329,7 +335,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938808,
+    "wof:lastmodified":1695885328,
     "wof:name":"Aglonas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/57/85685857.geojson
+++ b/data/856/858/57/85685857.geojson
@@ -299,11 +299,17 @@
         "gn:id":7628340,
         "gp:id":-2346042,
         "hasc:id":"LV.VV",
+        "iso:code":"LV-103",
         "iso:id":"LV-103",
+        "qs:local_id":"7691",
         "wd:id":"Q1023757"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"06ffc5f22da15586e4568eb4657af9f9",
+    "wof:geomhash":"c78b6b95341f69c512591aaca07a77a3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938803,
+    "wof:lastmodified":1695885328,
     "wof:name":"Varkavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/63/85685863.geojson
+++ b/data/856/858/63/85685863.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628334,
         "gp:id":-2346018,
         "hasc:id":"LV.NE",
+        "iso:code":"LV-065",
         "iso:id":"LV-065",
+        "qs:local_id":"3271",
         "wd:id":"Q2161795"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"3f52f05545d31faf3f9ba5e7540f773d",
+    "wof:geomhash":"a33dd5f541fdb7da2eea505119808bea",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938808,
+    "wof:lastmodified":1695885328,
     "wof:name":"Neretas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/67/85685867.geojson
+++ b/data/856/858/67/85685867.geojson
@@ -307,11 +307,17 @@
         "gn:id":7628305,
         "gp:id":-2346029,
         "hasc:id":"LV.AZ",
+        "iso:code":"LV-003",
         "iso:id":"LV-003",
+        "qs:local_id":"6406",
         "wd:id":"Q2485015"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"eda186cfe1ea5944c301ace3945d9066",
+    "wof:geomhash":"5d4ab401a368c45d863f2d4699ac68a9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -326,7 +332,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938804,
+    "wof:lastmodified":1695885328,
     "wof:name":"Aizputes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/71/85685871.geojson
+++ b/data/856/858/71/85685871.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628308,
         "gp:id":-2346029,
         "hasc:id":"LV.SK",
+        "iso:code":"LV-093",
         "iso:id":"LV-093",
+        "qs:local_id":"6212",
         "wd:id":"Q2299239"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"a01130203d4c06bcdb955edb1b61a296",
+    "wof:geomhash":"6d76cb2ab2f9ca19c7acb610ed526576",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938809,
+    "wof:lastmodified":1695885328,
     "wof:name":"Skrundas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/75/85685875.geojson
+++ b/data/856/858/75/85685875.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628335,
         "gp:id":-2346026,
         "hasc:id":"LV.VT",
+        "iso:code":"LV-107",
         "iso:id":"LV-107",
+        "qs:local_id":"5618",
         "wd:id":"Q2093996"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"2e986511cde33a693a414e63358d5689",
+    "wof:geomhash":"de06e6b8711833a0704961c4606f1709",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938806,
+    "wof:lastmodified":1695885328,
     "wof:name":"Viesites",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/81/85685881.geojson
+++ b/data/856/858/81/85685881.geojson
@@ -358,12 +358,18 @@
         "eurostat:nuts_2021_id":"0090000",
         "fips:code":"LG76",
         "hasc:id":"LV.JL",
+        "iso:code":"LV-041",
         "iso:id":"LV-041",
+        "qs:local_id":"0900",
         "unlc:id":"LV-JEL",
         "wd:id":"Q179830"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"87b65e516437240992cb2bf170ebeb07",
+    "wof:geomhash":"8de6aa67352a3d34690911081b0eaad4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -378,7 +384,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938807,
+    "wof:lastmodified":1695885328,
     "wof:name":"Jelgava",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/85/85685885.geojson
+++ b/data/856/858/85/85685885.geojson
@@ -292,11 +292,17 @@
         "gn:id":7628309,
         "gp:id":-2346029,
         "hasc:id":"LV.BR",
+        "iso:code":"LV-018",
         "iso:id":"LV-018",
+        "qs:local_id":"8406",
         "wd:id":"Q865717"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"54f282217e9644c78739e73d19e28644",
+    "wof:geomhash":"60648b8c27a64690aa247ff20fac82d8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938809,
+    "wof:lastmodified":1695885328,
     "wof:name":"Brocenu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/89/85685889.geojson
+++ b/data/856/858/89/85685889.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":4156,
     "eurostat:population_year":2020,
     "geom:area":0.131305,
-    "geom:area_square_m":901243405.923563,
+    "geom:area_square_m":901243442.22658,
     "geom:bbox":"25.672685,56.066531,26.336887,56.495127",
     "geom:latitude":56.283503,
     "geom:longitude":25.987721,
@@ -301,12 +301,18 @@
         "eurostat:nuts_2021_id":"0560200",
         "fips:code":"LG75",
         "hasc:id":"LV.JP",
+        "iso:code":"LV-042",
         "iso:id":"LV-042",
+        "qs:local_id":"5602",
         "unlc:id":"LV-042",
         "wd:id":"Q191120"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"bc0a55818c510b89ee29a06d46675386",
+    "wof:geomhash":"49cb8d8ad1c6ba9d68d09fa75cfd0ddd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -321,7 +327,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938806,
+    "wof:lastmodified":1695885328,
     "wof:name":"Jekabpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/858/93/85685893.geojson
+++ b/data/856/858/93/85685893.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628350,
         "gp:id":-2346042,
         "hasc:id":"LV.DD",
+        "iso:code":"LV-024",
         "iso:id":"LV-024",
+        "qs:local_id":"6010",
         "wd:id":"Q2361131"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e71d3d0391e0e9b49efc86bf60a2e5eb",
+    "wof:geomhash":"8de0eb679113f4709f44a09f52e0e072",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938804,
+    "wof:lastmodified":1695885328,
     "wof:name":"Dagdas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/01/85685901.geojson
+++ b/data/856/859/01/85685901.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628300,
         "gp:id":-2346029,
         "hasc:id":"LV.PT",
+        "iso:code":"LV-071",
         "iso:id":"LV-071",
+        "qs:local_id":"6414",
         "wd:id":"Q1942469"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"07ae9f1b5658ac09b8627f5ec795b253",
+    "wof:geomhash":"f6ae0e439223fea42c119c86d5bc708e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938786,
+    "wof:lastmodified":1695885329,
     "wof:name":"Pavilostas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/05/85685905.geojson
+++ b/data/856/859/05/85685905.geojson
@@ -299,11 +299,17 @@
         "gn:id":7628321,
         "gp:id":-2346026,
         "hasc:id":"LV.IE",
+        "iso:code":"LV-034",
         "iso:id":"LV-034",
+        "qs:local_id":"4064",
         "wd:id":"Q2337266"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"b1e9063475d587c095e74bf13da603ab",
+    "wof:geomhash":"0449a57f64172dd4d6ce2af46c97707a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938783,
+    "wof:lastmodified":1695885329,
     "wof:name":"Iecavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/07/85685907.geojson
+++ b/data/856/859/07/85685907.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628316,
         "gp:id":-2346026,
         "hasc:id":"LV.OZ",
+        "iso:code":"LV-069",
         "iso:id":"LV-069",
+        "qs:local_id":"5467",
         "wd:id":"Q2304926"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"1f61ff062958fcdde23785d3e718be0e",
+    "wof:geomhash":"feac023b95e84a9c59cb51d91a40b7fa",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938785,
+    "wof:lastmodified":1695885329,
     "wof:name":"Ozolnieku",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/11/85685911.geojson
+++ b/data/856/859/11/85685911.geojson
@@ -303,11 +303,17 @@
         "eurostat:nuts_2021_id":"0110000",
         "fips:code":"LG74",
         "hasc:id":"LV.JB",
+        "iso:code":"LV-JKB",
         "iso:id":"LV-JKB",
+        "qs:local_id":"1100",
         "wd:id":"Q191120"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e81508be664eff5332a3384f5d65c847",
+    "wof:geomhash":"1e1b0114dbf33f61157d2d08d7b20ad4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -322,7 +328,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938783,
+    "wof:lastmodified":1695885329,
     "wof:name":"Jekabpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/15/85685915.geojson
+++ b/data/856/859/15/85685915.geojson
@@ -5,13 +5,16 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008847,
-    "geom:area_square_m":60057107.048924,
+    "geom:area_square_m":60057201.596425,
     "geom:bbox":"24.000383,56.663942,24.256351,56.728592",
     "geom:latitude":56.703145,
     "geom:longitude":24.130833,
     "iso:country":"LV",
     "label:eng_x_preferred_longname":[
-        "Olaines Novads"
+        "Olaines Amalgamated Municipality"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "amalgamated municipality"
     ],
     "label:eng_x_preferred_shortcode":[
         "OL"
@@ -22,7 +25,7 @@
     "mps:latitude":56.698881,
     "mps:longitude":24.132718,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":10.0,
     "name:eng_x_preferred":[
@@ -60,7 +63,7 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"LV",
-    "wof:geomhash":"5c02d301ef6464fd400fd667b924357f",
+    "wof:geomhash":"890d45f7b1137f4e6e5b44dafd49d181",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -75,7 +78,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1636494714,
+    "wof:lastmodified":1694493127,
     "wof:name":"Olaines",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/15/85685915.geojson
+++ b/data/856/859/15/85685915.geojson
@@ -61,7 +61,14 @@
         85633279
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "iso:code":"LV-068",
+        "qs:local_id":"8010"
+    },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
     "wof:geomhash":"890d45f7b1137f4e6e5b44dafd49d181",
     "wof:hierarchy":[
@@ -78,7 +85,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1694493127,
+    "wof:lastmodified":1695884285,
     "wof:name":"Olaines",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/21/85685921.geojson
+++ b/data/856/859/21/85685921.geojson
@@ -291,12 +291,18 @@
         "gn:id":7628313,
         "gp:id":-2346037,
         "hasc:id":"LV.JU",
+        "iso:code":"LV-040",
         "iso:id":"LV-040",
+        "qs:local_id":"9057",
         "unlc:id":"LV-040",
         "wd:id":"Q2072154"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"fa4748ea5d4b660377ca25945b679660",
+    "wof:geomhash":"4df359b033a03179709ce8d52188b10d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938784,
+    "wof:lastmodified":1695885329,
     "wof:name":"Jaunpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/25/85685925.geojson
+++ b/data/856/859/25/85685925.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":19286,
     "eurostat:population_year":2020,
     "geom:area":0.129989,
-    "geom:area_square_m":884194526.060594,
+    "geom:area_square_m":884194574.669041,
     "geom:bbox":"22.775325,56.445774,23.530368,56.818353",
     "geom:latitude":56.626047,
     "geom:longitude":23.195574,
@@ -282,11 +282,17 @@
         "gn:id":460311,
         "gp:id":-2346024,
         "hasc:id":"LV.DB",
+        "iso:code":"LV-026",
         "iso:id":"LV-026",
+        "qs:local_id":"4602",
         "wd:id":"Q519580"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"27e47b886616f2f2004e80f3f75be52e",
+    "wof:geomhash":"265afda3ca6f86cd4488930637421d6e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -301,7 +307,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938788,
+    "wof:lastmodified":1695885329,
     "wof:name":"Dobeles",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/29/85685929.geojson
+++ b/data/856/859/29/85685929.geojson
@@ -296,11 +296,17 @@
         "gn:id":456528,
         "gp:id":-2346035,
         "hasc:id":"LV.PI",
+        "iso:code":"LV-073",
         "iso:id":"LV-073",
+        "qs:local_id":"7602",
         "wd:id":"Q2277469"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"d7db56fbaab79846076e0ef241d226ac",
+    "wof:geomhash":"c74db560ce671a4d5a2147f0fbb660cd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938783,
+    "wof:lastmodified":1695885329,
     "wof:name":"Preilu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/35/85685935.geojson
+++ b/data/856/859/35/85685935.geojson
@@ -292,12 +292,18 @@
         "gn:id":455888,
         "gp:id":-2346038,
         "hasc:id":"LV.SD",
+        "iso:code":"LV-088",
         "iso:id":"LV-088",
+        "qs:local_id":"8402",
         "unlc:id":"LV-088",
         "wd:id":"Q2299261"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"99c8f28cd772710868fa06589d8fe5c4",
+    "wof:geomhash":"6fa69d64b45e7fc153e5bc0845dcbe08",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938782,
+    "wof:lastmodified":1695885329,
     "wof:name":"Saldus",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/39/85685939.geojson
+++ b/data/856/859/39/85685939.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628329,
         "gp:id":-2346026,
         "hasc:id":"LV.VC",
+        "iso:code":"LV-105",
         "iso:id":"LV-105",
+        "qs:local_id":"4095",
         "wd:id":"Q2299436"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"0d5f61ea8dadaf183460c47d1f8f9541",
+    "wof:geomhash":"f925c0f7c49c27629506ae54bba560c3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938786,
+    "wof:lastmodified":1695885329,
     "wof:name":"Vecumnieku",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/43/85685943.geojson
+++ b/data/856/859/43/85685943.geojson
@@ -302,11 +302,17 @@
         "gn:id":7628341,
         "gp:id":55844714,
         "hasc:id":"LV.LV",
+        "iso:code":"LV-056",
         "iso:id":"LV-056",
+        "qs:local_id":"7612",
         "wd:id":"Q2277489"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"82fbe4debefe6072b16b21d507880234",
+    "wof:geomhash":"59304e28f9819e1df2064663cd4f0e16",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -321,7 +327,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938785,
+    "wof:lastmodified":1695885329,
     "wof:name":"Livanu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/47/85685947.geojson
+++ b/data/856/859/47/85685947.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628333,
         "gp:id":-2346026,
         "hasc:id":"LV.JJ",
+        "iso:code":"LV-038",
         "iso:id":"LV-038",
+        "qs:local_id":"3210",
         "wd:id":"Q2880128"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"c4e6b86d877abec62a43e40ecc5a46fe",
+    "wof:geomhash":"9d46ce1cb2da2c73a7d7d86c592450c0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938787,
+    "wof:lastmodified":1695885329,
     "wof:name":"Jaunjelgavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/53/85685953.geojson
+++ b/data/856/859/53/85685953.geojson
@@ -332,11 +332,17 @@
         "gn:id":7628336,
         "gp:id":-2346026,
         "hasc:id":"LV.SC",
+        "iso:code":"LV-086",
         "iso:id":"LV-086",
+        "qs:local_id":"5687",
         "wd:id":"Q2375848"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"8411a45112f04dcdff970e73128f2e8e",
+    "wof:geomhash":"c63e80215196bc000206cb7211d27670",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -351,7 +357,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938786,
+    "wof:lastmodified":1695885329,
     "wof:name":"Salas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/57/85685957.geojson
+++ b/data/856/859/57/85685957.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628324,
         "gp:id":-2346037,
         "hasc:id":"LV.BD",
+        "iso:code":"LV-013",
         "iso:id":"LV-013",
+        "qs:local_id":"8006",
         "wd:id":"Q2030886"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"41af56c68d4f8f92f42a7f24fb3a97b2",
+    "wof:geomhash":"400cf850e76a7ef232cb8a170392995e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938782,
+    "wof:lastmodified":1695885329,
     "wof:name":"Baldones",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/61/85685961.geojson
+++ b/data/856/859/61/85685961.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628299,
         "gp:id":-2346029,
         "hasc:id":"LV.AS",
+        "iso:code":"LV-006",
         "iso:id":"LV-006",
+        "qs:local_id":"6242",
         "wd:id":"Q1995769"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"cd82a3660c3b119f647f0bba11710c0e",
+    "wof:geomhash":"fb7893e275c1584e84bbe8add7e1d120",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938781,
+    "wof:lastmodified":1695885329,
     "wof:name":"Alsungas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/65/85685965.geojson
+++ b/data/856/859/65/85685965.geojson
@@ -293,11 +293,17 @@
         "gn:id":461613,
         "gp:id":-2346026,
         "hasc:id":"LV.AK",
+        "iso:code":"LV-002",
         "iso:id":"LV-002",
+        "qs:local_id":"3202",
         "wd:id":"Q865676"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"17952dadd6685bfa5a2736ee0f0c75ff",
+    "wof:geomhash":"1dfab6c95410f08e6f70f6ab6185c87b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938785,
+    "wof:lastmodified":1695885329,
     "wof:name":"Aizkraukles",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/71/85685971.geojson
+++ b/data/856/859/71/85685971.geojson
@@ -23,7 +23,10 @@
     "geom:longitude":23.654717,
     "iso:country":"LV",
     "label:eng_x_preferred_longname":[
-        "Jelgavas Novads"
+        "Jelgavas Republican City"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "republican city"
     ],
     "label:eng_x_preferred_shortcode":[
         "JE"
@@ -339,7 +342,7 @@
         "wd:id":"Q179830"
     },
     "wof:country":"LV",
-    "wof:geomhash":"d6b3040f27d425b60e7bb6009b9c1920",
+    "wof:geomhash":"b72233f81f7b10233853127b436be406",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -354,7 +357,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938787,
+    "wof:lastmodified":1694493293,
     "wof:name":"Jelgavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/71/85685971.geojson
+++ b/data/856/859/71/85685971.geojson
@@ -339,8 +339,14 @@
     "wof:concordances":{
         "eg:gisco_id":"LV_0540200",
         "eurostat:nuts_2021_id":"0540200",
+        "iso:code":"LV-041",
+        "qs:local_id":"5402",
         "wd:id":"Q179830"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
     "wof:geomhash":"b72233f81f7b10233853127b436be406",
     "wof:hierarchy":[
@@ -357,7 +363,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1694493293,
+    "wof:lastmodified":1695885329,
     "wof:name":"Jelgavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/75/85685975.geojson
+++ b/data/856/859/75/85685975.geojson
@@ -290,11 +290,17 @@
         "gn:id":7628332,
         "gp:id":-2346026,
         "hasc:id":"LV.SR",
+        "iso:code":"LV-092",
         "iso:id":"LV-092",
+        "qs:local_id":"3282",
         "wd:id":"Q2286864"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"92da3afc34fd8c5cb480af5cbb2b0e1b",
+    "wof:geomhash":"06ed6e972b3294118bd246ba88657680",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938784,
+    "wof:lastmodified":1695885329,
     "wof:name":"Skriveru",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/77/85685977.geojson
+++ b/data/856/859/77/85685977.geojson
@@ -296,11 +296,17 @@
         "gn:id":7628344,
         "gp:id":-2346042,
         "hasc:id":"LV.RB",
+        "iso:code":"LV-078",
         "iso:id":"LV-078",
+        "qs:local_id":"7663",
         "wd:id":"Q2106159"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"73f0ccc8080bdc9c5a56026055212199",
+    "wof:geomhash":"c9cf3ff9480088583c858ded835391e8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938787,
+    "wof:lastmodified":1695885329,
     "wof:name":"Riebinu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/81/85685981.geojson
+++ b/data/856/859/81/85685981.geojson
@@ -298,11 +298,17 @@
         "gn:id":7628320,
         "gp:id":-2346037,
         "hasc:id":"LV.OL",
+        "iso:code":"LV-068",
         "iso:id":"LV-068",
+        "qs:local_id":"8010",
         "wd:id":"Q2451375"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"9892b68118101159d60c0917adf6993a",
+    "wof:geomhash":"6d7d84ae9d625d7886c12f225af49b34",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +323,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938784,
+    "wof:lastmodified":1695885329,
     "wof:name":"Olaines",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/87/85685987.geojson
+++ b/data/856/859/87/85685987.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628347,
         "gp:id":55844452,
         "hasc:id":"LV.ZI",
+        "iso:code":"LV-110",
         "iso:id":"LV-110",
+        "qs:local_id":"6818",
         "wd:id":"Q3274762"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"fe1927ba0e402c1db0f060024997ab4b",
+    "wof:geomhash":"501f799176a8438ce21f437b412a4beb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938783,
+    "wof:lastmodified":1695885329,
     "wof:name":"Zilupes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/91/85685991.geojson
+++ b/data/856/859/91/85685991.geojson
@@ -298,12 +298,18 @@
         "gn:id":7628355,
         "gp:id":-2346026,
         "hasc:id":"LV.KT",
+        "iso:code":"LV-049",
         "iso:id":"LV-049",
+        "qs:local_id":"5669",
         "unlc:id":"LV-049",
         "wd:id":"Q2277478"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"8597c4200456c67fcadf8ef5e8fd6fea",
+    "wof:geomhash":"dc1780e8bbe532849894ed3a8a2537f9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938785,
+    "wof:lastmodified":1695885329,
     "wof:name":"Krustpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/95/85685995.geojson
+++ b/data/856/859/95/85685995.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628331,
         "gp:id":-2346037,
         "hasc:id":"LV.LL",
+        "iso:code":"LV-053",
         "iso:id":"LV-053",
+        "qs:local_id":"7414",
         "wd:id":"Q279004"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"943da3ad92bde7d6cebb64e9fea6c281",
+    "wof:geomhash":"5e67a4e48643a11c47a9cf65b1f4a122",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938782,
+    "wof:lastmodified":1695885329,
     "wof:name":"Lielvardes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/859/99/85685999.geojson
+++ b/data/856/859/99/85685999.geojson
@@ -296,11 +296,17 @@
         "gn:id":7628322,
         "gp:id":-2346037,
         "hasc:id":"LV.KK",
+        "iso:code":"LV-052",
         "iso:id":"LV-052",
+        "qs:local_id":"8008",
         "wd:id":"Q2268947"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"4dcca6eadde184fdb50ff30a7ba4a1eb",
+    "wof:geomhash":"b25f292146731efd19f35f5bceb7dae7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938787,
+    "wof:lastmodified":1695885329,
     "wof:name":"Kekavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/01/85686001.geojson
+++ b/data/856/860/01/85686001.geojson
@@ -379,15 +379,21 @@
         "gn:id":456203,
         "gp:id":-20070123,
         "hasc:id":"LV.RE",
+        "iso:code":"LV-077",
         "iso:id":"LV-077",
+        "qs:local_id":"2100",
         "unlc:id":"LV-REZ",
         "wd:id":"Q180379"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101816353
     ],
     "wof:country":"LV",
-    "wof:geomhash":"c4ebe73820ef417b1010c3c64e3d1010",
+    "wof:geomhash":"98adb33682fbf6616d5e9518fa9aa2c1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -402,7 +408,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938801,
+    "wof:lastmodified":1695885329,
     "wof:name":"Rezekne",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/07/85686007.geojson
+++ b/data/856/860/07/85686007.geojson
@@ -302,11 +302,17 @@
         "gn:id":7628319,
         "gp:id":-2346037,
         "hasc:id":"LV.MR",
+        "iso:code":"LV-062",
         "iso:id":"LV-062",
+        "qs:local_id":"8076",
         "wd:id":"Q2232018"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"15f4af5b4c3363da7039adec65b6099d",
+    "wof:geomhash":"2c8ef8deaa9516d31cfe81b544408a5f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -321,7 +327,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938799,
+    "wof:lastmodified":1695885329,
     "wof:name":"Marupes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/11/85686011.geojson
+++ b/data/856/860/11/85686011.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628330,
         "gp:id":-2346037,
         "hasc:id":"LV.KG",
+        "iso:code":"LV-051",
         "iso:id":"LV-051",
+        "qs:local_id":"7410",
         "wd:id":"Q2072209"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"61a3a493de80b64ff3491028bca8db89",
+    "wof:geomhash":"4e7ed093571f06631231d188096c5321",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938798,
+    "wof:lastmodified":1695885329,
     "wof:name":"Keguma",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/15/85686015.geojson
+++ b/data/856/860/15/85686015.geojson
@@ -298,12 +298,18 @@
         "gn:id":7628323,
         "gp:id":-2346037,
         "hasc:id":"LV.SS",
+        "iso:code":"LV-087",
         "iso:id":"LV-087",
+        "qs:local_id":"8012",
         "unlc:id":"LV-087",
         "wd:id":"Q2140753"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"63928190d4b0f10af6831556e29de769",
+    "wof:geomhash":"e83c075c4a78631bbe149685f6ee8673",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938802,
+    "wof:lastmodified":1695885330,
     "wof:name":"Salaspils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/17/85686017.geojson
+++ b/data/856/860/17/85686017.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":9888,
     "eurostat:population_year":2020,
     "geom:area":0.019227,
-    "geom:area_square_m":129973563.526713,
+    "geom:area_square_m":129973409.960977,
     "geom:bbox":"24.432586,56.806273,24.768151,56.90686",
     "geom:latitude":56.860329,
     "geom:longitude":24.583374,
@@ -284,11 +284,17 @@
         "gn:id":7628358,
         "gp:id":-2346037,
         "hasc:id":"LV.IK",
+        "iso:code":"LV-035",
         "iso:id":"LV-035",
+        "qs:local_id":"7406",
         "wd:id":"Q2337298"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"27d27ab70b97b9d6a817b5badc9ac4c9",
+    "wof:geomhash":"c9fdb1ade4e93d00216e04c974427755",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -303,7 +309,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938798,
+    "wof:lastmodified":1695885330,
     "wof:name":"Ik\u0161kiles",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/23/85686023.geojson
+++ b/data/856/860/23/85686023.geojson
@@ -294,11 +294,17 @@
         "gn:id":7628357,
         "gp:id":-2346026,
         "hasc:id":"LV.KO",
+        "iso:code":"LV-046",
         "iso:id":"LV-046",
+        "qs:local_id":"3261",
         "wd:id":"Q865682"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"47719b11e620ae6774c230ebecd3e3fd",
+    "wof:geomhash":"44488fa81dffe1caa45538b52a969585",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +319,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938802,
+    "wof:lastmodified":1695885330,
     "wof:name":"Kokneses",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/27/85686027.geojson
+++ b/data/856/860/27/85686027.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628318,
         "gp:id":-2346037,
         "hasc:id":"LV.BB",
+        "iso:code":"LV-012",
         "iso:id":"LV-012",
+        "qs:local_id":"8049",
         "wd:id":"Q2079353"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"6d1eb1a8dcd0efebda7fa30eeb0a595d",
+    "wof:geomhash":"973cd5a8d61981a78907b66751edf8ba",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938797,
+    "wof:lastmodified":1695885330,
     "wof:name":"Babites",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/31/85686031.geojson
+++ b/data/856/860/31/85686031.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":49687,
     "eurostat:population_year":2020,
     "geom:area":0.01495,
-    "geom:area_square_m":100788820.137244,
+    "geom:area_square_m":100788581.664142,
     "geom:bbox":"23.473392,56.923808,23.970957,57.00856",
     "geom:latitude":56.959355,
     "geom:longitude":23.693584,
@@ -406,12 +406,18 @@
         "gn:id":459202,
         "gp:id":-2346037,
         "hasc:id":"LV.JM",
+        "iso:code":"LV-JUR",
         "iso:id":"LV-JUR",
+        "qs:local_id":"1300",
         "unlc:id":"LV-JUR",
         "wd:id":"Q178382"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"7751b36289c23e9c7ea85ae179318d16",
+    "wof:geomhash":"9ec5722da7f9479c052f853c0b10018a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -426,7 +432,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938799,
+    "wof:lastmodified":1695885330,
     "wof:name":"Jurmala",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/33/85686033.geojson
+++ b/data/856/860/33/85686033.geojson
@@ -299,11 +299,17 @@
         "gn:id":7628325,
         "gp:id":-2346037,
         "hasc:id":"LV.SP",
+        "iso:code":"LV-095",
         "iso:id":"LV-095",
+        "qs:local_id":"8096",
         "wd:id":"Q2299214"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"637ab6bbc6e9bf82ba17dba7c2be8567",
+    "wof:geomhash":"d4c78c067c8f8fc5d1d883e6244a6489",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938797,
+    "wof:lastmodified":1695885330,
     "wof:name":"Stopinu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/37/85686037.geojson
+++ b/data/856/860/37/85686037.geojson
@@ -270,11 +270,17 @@
         "gn:id":457773,
         "gp:id":-2346032,
         "hasc:id":"LV.LZ",
+        "iso:code":"LV-058",
         "iso:id":"LV-058",
+        "qs:local_id":"6802",
         "wd:id":"Q744259"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"0b6b2996872d32365932464b7bd960e7",
+    "wof:geomhash":"f5f1dfaf2c7d2a711172e7128dfb5f71",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -289,7 +295,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938800,
+    "wof:lastmodified":1695885330,
     "wof:name":"Ludzas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/43/85686043.geojson
+++ b/data/856/860/43/85686043.geojson
@@ -305,11 +305,17 @@
         "gn:id":458459,
         "gp:id":-2346029,
         "hasc:id":"LV.KD",
+        "iso:code":"LV-050",
         "iso:id":"LV-050",
+        "qs:local_id":"6202",
         "wd:id":"Q2337188"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"6d287297448d689a868082f957a5fdef",
+    "wof:geomhash":"65ce8bff2af2be2384b5c701cb98a424",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -324,7 +330,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938799,
+    "wof:lastmodified":1695885330,
     "wof:name":"Kuldigas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/49/85686049.geojson
+++ b/data/856/860/49/85686049.geojson
@@ -299,11 +299,17 @@
         "gn:id":7628343,
         "gp:id":-2346042,
         "hasc:id":"LV.VI",
+        "iso:code":"LV-109",
         "iso:id":"LV-109",
+        "qs:local_id":"7818",
         "wd:id":"Q2018681"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"52bc7068798e96209c48067305a93d91",
+    "wof:geomhash":"ffc4143502497b1a49c64f8673e0a649",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938803,
+    "wof:lastmodified":1695885330,
     "wof:name":"Vilanu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/51/85686051.geojson
+++ b/data/856/860/51/85686051.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2990,
     "eurostat:population_year":2020,
     "geom:area":0.040675,
-    "geom:area_square_m":276648340.245942,
+    "geom:area_square_m":276648256.321191,
     "geom:bbox":"26.376042,56.534897,26.791855,56.714566",
     "geom:latitude":56.629925,
     "geom:longitude":26.614311,
@@ -293,11 +293,17 @@
         "gn:id":7628342,
         "gp:id":-2346042,
         "hasc:id":"LV.VX",
+        "iso:code":"LV-102",
         "iso:id":"LV-102",
+        "qs:local_id":"7018",
         "wd:id":"Q432596"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"9159a9505cac7e9dac445b24dd85a21d",
+    "wof:geomhash":"93b2d8bcb8342709d4c70de711d43a7d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938797,
+    "wof:lastmodified":1695885330,
     "wof:name":"Varaklanu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/55/85686055.geojson
+++ b/data/856/860/55/85686055.geojson
@@ -296,11 +296,17 @@
         "gn:id":7628356,
         "gp:id":-2346026,
         "hasc:id":"LV.PL",
+        "iso:code":"LV-072",
         "iso:id":"LV-072",
+        "qs:local_id":"3214",
         "wd:id":"Q865649"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"dce1ff93d6ffb01ed3958a7e5553ceb4",
+    "wof:geomhash":"a7e6ad4a79871ebc00c6087a119e110f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938801,
+    "wof:lastmodified":1695885330,
     "wof:name":"Plavinu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/61/85686061.geojson
+++ b/data/856/860/61/85686061.geojson
@@ -292,11 +292,17 @@
         "gn:id":7628311,
         "gp:id":-2346037,
         "hasc:id":"LV.KN",
+        "iso:code":"LV-043",
         "iso:id":"LV-043",
+        "qs:local_id":"9012",
         "wd:id":"Q2024643"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"396b731a0c1e11d1a797084fcbe3ba21",
+    "wof:geomhash":"f9117094bf12b6f17b35a4b21d6aedec",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938796,
+    "wof:lastmodified":1695885330,
     "wof:name":"Kandavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/65/85686065.geojson
+++ b/data/856/860/65/85686065.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":627487,
     "eurostat:population_year":2020,
     "geom:area":0.044824,
-    "geom:area_square_m":302046855.1369,
+    "geom:area_square_m":302046850.376559,
     "geom:bbox":"23.932331,56.857363,24.324504,57.085617",
     "geom:latitude":56.977925,
     "geom:longitude":24.122545,
@@ -736,15 +736,21 @@
         "gn:id":456173,
         "gp:id":-20070121,
         "hasc:id":"LV.RA",
+        "iso:code":"LV-RIX",
         "iso:id":"LV-RIX",
+        "qs:local_id":"0100",
         "unlc:id":"LV-RIX",
         "wd:id":"Q1773"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101751789
     ],
     "wof:country":"LV",
-    "wof:geomhash":"d170f69fde761f807419bdb9a53c6a1d",
+    "wof:geomhash":"3577ed341a80184b45782e0b39b44d49",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -759,7 +765,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938800,
+    "wof:lastmodified":1695885330,
     "wof:name":"Riga",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/69/85686069.geojson
+++ b/data/856/860/69/85686069.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":6835,
     "eurostat:population_year":2020,
     "geom:area":0.047982,
-    "geom:area_square_m":323430224.826755,
+    "geom:area_square_m":323430479.145221,
     "geom:bbox":"24.366765,56.889055,24.820866,57.06806",
     "geom:latitude":56.966199,
     "geom:longitude":24.596772,
@@ -287,11 +287,17 @@
         "gn:id":7628359,
         "gp:id":-2346037,
         "hasc:id":"LV.RP",
+        "iso:code":"LV-080",
         "iso:id":"LV-080",
+        "qs:local_id":"8084",
         "wd:id":"Q11068461"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"ebf573aaae0d2eeb6faa1edba573c9b5",
+    "wof:geomhash":"ee2491b16b327f349011a0bc0d1fef85",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +312,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938797,
+    "wof:lastmodified":1695885330,
     "wof:name":"Ropa\u017eu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/73/85686073.geojson
+++ b/data/856/860/73/85686073.geojson
@@ -292,11 +292,17 @@
         "gn:id":7628328,
         "gp:id":-2346037,
         "hasc:id":"LV.GA",
+        "iso:code":"LV-031",
         "iso:id":"LV-031",
+        "qs:local_id":"8060",
         "wd:id":"Q2171669"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"707303a6123e6bd689b430c0fc195092",
+    "wof:geomhash":"59e07911dd4c4ecac0e99b8fb58de884",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938798,
+    "wof:lastmodified":1695885330,
     "wof:name":"Garkalnes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/79/85686079.geojson
+++ b/data/856/860/79/85686079.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":32987,
     "eurostat:population_year":2020,
     "geom:area":0.145841,
-    "geom:area_square_m":986100610.898052,
+    "geom:area_square_m":986100713.414161,
     "geom:bbox":"24.555719,56.695318,25.550472,56.997415",
     "geom:latitude":56.851297,
     "geom:longitude":25.133191,
@@ -358,11 +358,17 @@
         "gn:id":457061,
         "gp:id":-2346034,
         "hasc:id":"LV.OR",
+        "iso:code":"LV-067",
         "iso:id":"LV-067",
+        "qs:local_id":"7402",
         "wd:id":"Q2321579"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"7bf73407f341f3ea0629f79ed0b4d117",
+    "wof:geomhash":"a616b9b9db85cc9dda9a5b65351d6f33",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -377,7 +383,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938801,
+    "wof:lastmodified":1695885330,
     "wof:name":"Ogres",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/83/85686083.geojson
+++ b/data/856/860/83/85686083.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":27613,
     "eurostat:population_year":2020,
     "geom:area":0.176324,
-    "geom:area_square_m":1189446862.578814,
+    "geom:area_square_m":1189446667.301993,
     "geom:bbox":"22.805949,56.69129,23.506191,57.252285",
     "geom:latitude":56.937716,
     "geom:longitude":23.117666,
@@ -291,11 +291,17 @@
         "gn:id":454771,
         "gp:id":-2346040,
         "hasc:id":"LV.TK",
+        "iso:code":"LV-099",
         "iso:id":"LV-099",
+        "qs:local_id":"9002",
         "wd:id":"Q369007"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"a1a6118c3e4275fe9c6d86687e6d1946",
+    "wof:geomhash":"d6325e304e8289f87584d4315f38b5ad",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -310,7 +316,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938802,
+    "wof:lastmodified":1695885330,
     "wof:name":"Tukuma",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/85/85686085.geojson
+++ b/data/856/860/85/85686085.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2611,
     "eurostat:population_year":2020,
     "geom:area":0.05586,
-    "geom:area_square_m":377220110.855737,
+    "geom:area_square_m":377220124.927056,
     "geom:bbox":"25.479614,56.769089,25.946807,57.000671",
     "geom:latitude":56.898414,
     "geom:longitude":25.673767,
@@ -290,11 +290,17 @@
         "gn:id":7628382,
         "gp:id":-2346042,
         "hasc:id":"LV.ER",
+        "iso:code":"LV-030",
         "iso:id":"LV-030",
+        "qs:local_id":"7055",
         "wd:id":"Q2079406"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"8046608e9b0763710c181e7b0c5cf3cc",
+    "wof:geomhash":"606324ceda05a61036d1f7974cb831c7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938803,
+    "wof:lastmodified":1695885330,
     "wof:name":"Erglu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/89/85686089.geojson
+++ b/data/856/860/89/85686089.geojson
@@ -298,11 +298,17 @@
         "gn:id":7628346,
         "gp:id":-2346042,
         "hasc:id":"LV.CI",
+        "iso:code":"LV-023",
         "iso:id":"LV-023",
+        "qs:local_id":"6849",
         "wd:id":"Q1955102"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"800e66ea80df5252442c49607e8dc1fd",
+    "wof:geomhash":"30c37494622dd310a8e9bcaf421fe274",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +323,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938798,
+    "wof:lastmodified":1695885330,
     "wof:name":"Ciblas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/95/85686095.geojson
+++ b/data/856/860/95/85686095.geojson
@@ -384,11 +384,17 @@
         "gn:id":456197,
         "gp:id":-2346036,
         "hasc:id":"LV.RK",
+        "iso:code":"LV-REZ",
         "iso:id":"LV-REZ",
+        "qs:local_id":"7802",
         "wd:id":"Q180379"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"790edc4ab5fab4a95e69a913ebb0de27",
+    "wof:geomhash":"75275f14c53f27e15e7e63c855cf9674",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -403,7 +409,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938796,
+    "wof:lastmodified":1695885330,
     "wof:name":"Rezeknes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/860/99/85686099.geojson
+++ b/data/856/860/99/85686099.geojson
@@ -293,12 +293,18 @@
         "gn:id":7628364,
         "gp:id":-2346037,
         "hasc:id":"LV.ML",
+        "iso:code":"LV-061",
         "iso:id":"LV-061",
+        "qs:local_id":"8074",
         "unlc:id":"LV-061",
         "wd:id":"Q2304902"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"4ec5da91cd8431db87c55722bf83aede",
+    "wof:geomhash":"1307ef0365ec933d61485d4be3d5b952",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +319,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938801,
+    "wof:lastmodified":1695885330,
     "wof:name":"Malpils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/03/85686103.geojson
+++ b/data/856/861/03/85686103.geojson
@@ -298,11 +298,17 @@
         "gn:id":7628314,
         "gp:id":-2346037,
         "hasc:id":"LV.EN",
+        "iso:code":"LV-029",
         "iso:id":"LV-029",
+        "qs:local_id":"9051",
         "wd:id":"Q2079455"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e6b16193a96639f79e685ce35ff636d7",
+    "wof:geomhash":"20460cbd13bd2e0768305d01633bb54c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +323,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938789,
+    "wof:lastmodified":1695885330,
     "wof:name":"Engures",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/07/85686107.geojson
+++ b/data/856/861/07/85686107.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628326,
         "gp:id":-2346037,
         "hasc:id":"LV.CR",
+        "iso:code":"LV-020",
         "iso:id":"LV-020",
+        "qs:local_id":"8052",
         "wd:id":"Q2453125"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"5dc945b598c382cfdb2a8ee2b17fd3e6",
+    "wof:geomhash":"b47515d29cc12a04ba81203a8f72071e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938792,
+    "wof:lastmodified":1695885330,
     "wof:name":"Carnikavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/13/85686113.geojson
+++ b/data/856/861/13/85686113.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11625,
     "eurostat:population_year":2020,
     "geom:area":0.024116,
-    "geom:area_square_m":161931117.953935,
+    "geom:area_square_m":161930953.785265,
     "geom:bbox":"24.241996,57.026745,24.509105,57.188583",
     "geom:latitude":57.109444,
     "geom:longitude":24.380584,
@@ -296,11 +296,17 @@
         "gn:id":7628327,
         "gp:id":-2346037,
         "hasc:id":"LV.AD",
+        "iso:code":"LV-011",
         "iso:id":"LV-011",
+        "qs:local_id":"8044",
         "wd:id":"Q3019837"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"424233d470b368882b1f319c44dff647",
+    "wof:geomhash":"c1ab9b7627773efc25295cc994487fa3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -315,7 +321,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938794,
+    "wof:lastmodified":1695885330,
     "wof:name":"Ada\u017eu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/17/85686117.geojson
+++ b/data/856/861/17/85686117.geojson
@@ -298,11 +298,17 @@
         "gn:id":7628360,
         "gp:id":-2346037,
         "hasc:id":"LV.IN",
+        "iso:code":"LV-037",
         "iso:id":"LV-037",
+        "qs:local_id":"8018",
         "wd:id":"Q2252820"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"6d5b7f2650f0fa21b585b3248aa40ba0",
+    "wof:geomhash":"af0df01580480ff2229fd3ebf10ca145",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +323,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938791,
+    "wof:lastmodified":1695885330,
     "wof:name":"Incukalna",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/23/85686123.geojson
+++ b/data/856/861/23/85686123.geojson
@@ -357,11 +357,17 @@
         "eurostat:nuts_2021_id":"0270000",
         "fips:code":"LG32",
         "hasc:id":"LV.VS",
+        "iso:code":"LV-VEN",
         "iso:id":"LV-VEN",
+        "qs:local_id":"2700",
         "wd:id":"Q104036"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"214b98d369422372303bdce34778c68f",
+    "wof:geomhash":"1d39b6b08366d35945835b20bec79036",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -376,7 +382,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938793,
+    "wof:lastmodified":1695885331,
     "wof:name":"Ventspils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/25/85686125.geojson
+++ b/data/856/861/25/85686125.geojson
@@ -293,11 +293,17 @@
         "gn:id":8299767,
         "gp:id":-2346039,
         "hasc:id":"LV.ME",
+        "iso:code":"LV-063",
         "iso:id":"LV-063",
+        "qs:local_id":"8876",
         "wd:id":"Q2416186"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"76a42372243792072078ced33cd3934e",
+    "wof:geomhash":"fac047e285cd0a8f5719eb5aa3d6f6f9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938794,
+    "wof:lastmodified":1695885331,
     "wof:name":"Mersraga",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/31/85686131.geojson
+++ b/data/856/861/31/85686131.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2148,
     "eurostat:population_year":2020,
     "geom:area":0.05115,
-    "geom:area_square_m":345343854.71061,
+    "geom:area_square_m":345344056.044889,
     "geom:bbox":"26.464521,56.795879,26.991629,56.997066",
     "geom:latitude":56.905165,
     "geom:longitude":26.719741,
@@ -314,11 +314,17 @@
         "gn:id":7628354,
         "gp:id":-2346042,
         "hasc:id":"LV.LB",
+        "iso:code":"LV-057",
         "iso:id":"LV-057",
+        "qs:local_id":"7014",
         "wd:id":"Q2072165"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"ea9cb7ff62ca6eaf48203741f4c06818",
+    "wof:geomhash":"e7d30b2d484533cc54fee37b999a238e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -333,7 +339,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938792,
+    "wof:lastmodified":1695885331,
     "wof:name":"Lubanas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/35/85686135.geojson
+++ b/data/856/861/35/85686135.geojson
@@ -289,11 +289,17 @@
         "gn:id":7628362,
         "gp:id":-2346037,
         "hasc:id":"LV.SI",
+        "iso:code":"LV-091",
         "iso:id":"LV-091",
+        "qs:local_id":"8016",
         "wd:id":"Q2299251"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"85d51ab64c63b0ce5841837337365463",
+    "wof:geomhash":"d1d570d29508be48937355f507cb46d0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938789,
+    "wof:lastmodified":1695885331,
     "wof:name":"Siguldas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/39/85686139.geojson
+++ b/data/856/861/39/85686139.geojson
@@ -298,11 +298,17 @@
         "gn:id":7628351,
         "gp:id":-2346042,
         "hasc:id":"LV.KA",
+        "iso:code":"LV-044",
         "iso:id":"LV-044",
+        "qs:local_id":"6810",
         "wd:id":"Q2395952"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"f91da4d657cb3259c3d6eeb294e32ba8",
+    "wof:geomhash":"a3dbc1fb92f9ef64511fc50fe4c608b8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -317,7 +323,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938793,
+    "wof:lastmodified":1695885331,
     "wof:name":"Karsavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/43/85686143.geojson
+++ b/data/856/861/43/85686143.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":21879,
     "eurostat:population_year":2020,
     "geom:area":0.31778,
-    "geom:area_square_m":2149801955.174335,
+    "geom:area_square_m":2149801611.812573,
     "geom:bbox":"25.725147,56.585261,26.943583,57.102065",
     "geom:latitude":56.83157,
     "geom:longitude":26.265996,
@@ -294,11 +294,17 @@
         "gn:id":457712,
         "gp:id":-2346033,
         "hasc:id":"LV.MD",
+        "iso:code":"LV-059",
         "iso:id":"LV-059",
+        "qs:local_id":"7002",
         "wd:id":"Q2198472"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e964561c9938886344e73f86be0db001",
+    "wof:geomhash":"76dcc8abdaa9bf45e160316146814a9e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -313,7 +319,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938791,
+    "wof:lastmodified":1695885331,
     "wof:name":"Madonas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/51/85686151.geojson
+++ b/data/856/861/51/85686151.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2266,
     "eurostat:population_year":2020,
     "geom:area":0.028135,
-    "geom:area_square_m":189441005.420608,
+    "geom:area_square_m":189440937.037425,
     "geom:bbox":"26.157022,56.922532,26.410657,57.095529",
     "geom:latitude":57.007626,
     "geom:longitude":26.2772,
@@ -289,11 +289,17 @@
         "gn:id":7628353,
         "gp:id":-2346042,
         "hasc:id":"LV.CV",
+        "iso:code":"LV-021",
         "iso:id":"LV-021",
+        "qs:local_id":"7008",
         "wd:id":"Q2327041"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"17b1491ba8842bcd23c1d534f8bfab04",
+    "wof:geomhash":"ae1b28b27c5aeaecd361eabf11ddf0b5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938789,
+    "wof:lastmodified":1695885331,
     "wof:name":"Cesvaines",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/53/85686153.geojson
+++ b/data/856/861/53/85686153.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3266,
     "eurostat:population_year":2020,
     "geom:area":0.0249,
-    "geom:area_square_m":166839004.949386,
+    "geom:area_square_m":166839171.132536,
     "geom:bbox":"24.900559,57.118821,25.196835,57.260747",
     "geom:latitude":57.189267,
     "geom:longitude":25.059174,
@@ -289,11 +289,17 @@
         "gn:id":7628363,
         "gp:id":-2346042,
         "hasc:id":"LV.LG",
+        "iso:code":"LV-055",
         "iso:id":"LV-055",
+        "qs:local_id":"4212",
         "wd:id":"Q1023736"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"93bb9f49c00c232df831ac21c9380a1e",
+    "wof:geomhash":"0caa241f30c8caf263d66c5951ec4986",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938792,
+    "wof:lastmodified":1695885331,
     "wof:name":"Ligatnes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/57/85686157.geojson
+++ b/data/856/861/57/85686157.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":27425,
     "eurostat:population_year":2020,
     "geom:area":0.262472,
-    "geom:area_square_m":1755361150.225204,
+    "geom:area_square_m":1755361359.573352,
     "geom:bbox":"22.179075,57.00384,23.088608,57.50996",
     "geom:latitude":57.257935,
     "geom:longitude":22.606523,
@@ -290,11 +290,17 @@
         "gn:id":454968,
         "gp:id":-2346039,
         "hasc:id":"LV.TL",
+        "iso:code":"LV-097",
         "iso:id":"LV-097",
+        "qs:local_id":"8802",
         "wd:id":"Q2302964"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"6ff6a50fb43f35cd3638ba48c6e7eb1b",
+    "wof:geomhash":"1a62c155a6c48c2cb509c85de7827382",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938788,
+    "wof:lastmodified":1695885331,
     "wof:name":"Talsu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/61/85686161.geojson
+++ b/data/856/861/61/85686161.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628365,
         "gp:id":-2346037,
         "hasc:id":"LV.SE",
+        "iso:code":"LV-090",
         "iso:id":"LV-090",
+        "qs:local_id":"8092",
         "wd:id":"Q2299447"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"0b57d46dcb94c52c7b9cac5c276e3366",
+    "wof:geomhash":"66e72690f7dc3487ab3a8212d366fbbf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938788,
+    "wof:lastmodified":1695885331,
     "wof:name":"Sejas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/69/85686169.geojson
+++ b/data/856/861/69/85686169.geojson
@@ -287,11 +287,17 @@
         "gn:id":7628366,
         "gp:id":-2346037,
         "hasc:id":"LV.SU",
+        "iso:code":"LV-089",
         "iso:id":"LV-089",
+        "qs:local_id":"8014",
         "wd:id":"Q371429"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"867efcf51a7c0ca28b9c9e18254041fe",
+    "wof:geomhash":"6de4a6487b3bf9ba2f05f259e292f6f5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +312,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938789,
+    "wof:lastmodified":1695885331,
     "wof:name":"Saulkrastu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/73/85686173.geojson
+++ b/data/856/861/73/85686173.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":4979,
     "eurostat:population_year":2020,
     "geom:area":0.110517,
-    "geom:area_square_m":742245158.764955,
+    "geom:area_square_m":742245055.774399,
     "geom:bbox":"25.07694,56.926162,25.611866,57.300637",
     "geom:latitude":57.101768,
     "geom:longitude":25.316074,
@@ -281,11 +281,17 @@
         "gn:id":7628375,
         "gp:id":-2346042,
         "hasc:id":"LV.AM",
+        "iso:code":"LV-008",
         "iso:id":"LV-008",
+        "qs:local_id":"4247",
         "wd:id":"Q1892063"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"2509388171a55b57fe0ec41e465e3077",
+    "wof:geomhash":"df85439ebbc074bb9c3322dd2615ebf7",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +306,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938790,
+    "wof:lastmodified":1695885331,
     "wof:name":"Amatas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/75/85686175.geojson
+++ b/data/856/861/75/85686175.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":1982,
     "eurostat:population_year":2020,
     "geom:area":0.037285,
-    "geom:area_square_m":250083230.125269,
+    "geom:area_square_m":250082966.142201,
     "geom:bbox":"25.757395,57.07755,26.166142,57.218391",
     "geom:latitude":57.150116,
     "geom:longitude":25.974333,
@@ -286,11 +286,17 @@
         "gn:id":7628381,
         "gp:id":-2346042,
         "hasc:id":"LV.JA",
+        "iso:code":"LV-039",
         "iso:id":"LV-039",
+        "qs:local_id":"4257",
         "wd:id":"Q2306846"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"5c2ae91c6b818dba73dddf24d4e4b28c",
+    "wof:geomhash":"749656cc85b4774bf2cfe06c8fc12660",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -305,7 +311,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938791,
+    "wof:lastmodified":1695885331,
     "wof:name":"Jaunpiepalgas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/79/85686179.geojson
+++ b/data/856/861/79/85686179.geojson
@@ -297,11 +297,17 @@
         "gn:id":7628349,
         "gp:id":-2346042,
         "hasc:id":"LV.BA",
+        "iso:code":"LV-014",
         "iso:id":"LV-014",
+        "qs:local_id":"3844",
         "wd:id":"Q2361012"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"8ac2142ef1d92ac2d9a2f256f6339a6d",
+    "wof:geomhash":"22f4804303fa283ed3154e8fda4cebb8",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -316,7 +322,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938793,
+    "wof:lastmodified":1695885331,
     "wof:name":"Baltinavas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/85/85686185.geojson
+++ b/data/856/861/85/85686185.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628352,
         "gp:id":-2346042,
         "hasc:id":"LV.RJ",
+        "iso:code":"LV-082",
         "iso:id":"LV-082",
+        "qs:local_id":"3875",
         "wd:id":"Q1837354"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"f98ec68a9fd0fb860c2264814c1eff02",
+    "wof:geomhash":"01496d2484e666f7054263d3a119f636",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938794,
+    "wof:lastmodified":1695885331,
     "wof:name":"Rugaju",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/89/85686189.geojson
+++ b/data/856/861/89/85686189.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3555,
     "eurostat:population_year":2020,
     "geom:area":0.080376,
-    "geom:area_square_m":539854328.527418,
+    "geom:area_square_m":539854191.584927,
     "geom:bbox":"25.449578,56.958878,25.927059,57.280876",
     "geom:latitude":57.099355,
     "geom:longitude":25.704116,
@@ -288,11 +288,17 @@
         "gn:id":7628383,
         "gp:id":-2346042,
         "hasc:id":"LV.VB",
+        "iso:code":"LV-104",
         "iso:id":"LV-104",
+        "qs:local_id":"4293",
         "wd:id":"Q1920815"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"a55018c1d34317dbe3073c10ad004480",
+    "wof:geomhash":"db06b7d22515e70d96f0df21965f8632",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -307,7 +313,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938790,
+    "wof:lastmodified":1695885331,
     "wof:name":"Vecpiebalgas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/93/85686193.geojson
+++ b/data/856/861/93/85686193.geojson
@@ -311,11 +311,17 @@
         "gn:id":460569,
         "gp:id":-2346022,
         "hasc:id":"LV.CS",
+        "iso:code":"LV-022",
         "iso:id":"LV-022",
+        "qs:local_id":"4202",
         "wd:id":"Q1989164"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"8a33744f19d11f46cc9747cc152085a5",
+    "wof:geomhash":"065d44788a3d0bb2b5266887f1f257da",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -330,7 +336,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938790,
+    "wof:lastmodified":1695885331,
     "wof:name":"Cesu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/861/97/85686197.geojson
+++ b/data/856/861/97/85686197.geojson
@@ -368,12 +368,18 @@
         "eurostat:nuts_2021_id":"0980200",
         "fips:code":"LGE5",
         "hasc:id":"LV.VN",
+        "iso:code":"LV-106",
         "iso:id":"LV-106",
+        "qs:local_id":"9802",
         "unlc:id":"LV-106",
         "wd:id":"Q104036"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"81ddb42738cf049734733fa5decfdcbc",
+    "wof:geomhash":"29bce104cf4509dab758e008f29f1777",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -388,7 +394,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938793,
+    "wof:lastmodified":1695885331,
     "wof:name":"Ventspils",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/03/85686203.geojson
+++ b/data/856/862/03/85686203.geojson
@@ -292,11 +292,17 @@
         "gn:id":7628361,
         "gp:id":-2346037,
         "hasc:id":"LV.KM",
+        "iso:code":"LV-048",
         "iso:id":"LV-048",
+        "qs:local_id":"8069",
         "wd:id":"Q2302998"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"74f8d11a55b4ce9085239f0ed60efac3",
+    "wof:geomhash":"b408bd4cfe6d394b2002c05a1e8a4e9d",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938811,
+    "wof:lastmodified":1695885331,
     "wof:name":"Krimuldas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/07/85686207.geojson
+++ b/data/856/862/07/85686207.geojson
@@ -71,8 +71,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"LV_0427700",
-        "eurostat:nuts_2021_id":"0427700"
+        "eurostat:nuts_2021_id":"0427700",
+        "iso:code":"LV-076",
+        "qs:local_id":"4277"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
     "wof:geomhash":"7f44bf3978f77af6ae901e1c71c31788",
     "wof:hierarchy":[
@@ -89,7 +95,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884322,
     "wof:name":"Raunas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/07/85686207.geojson
+++ b/data/856/862/07/85686207.geojson
@@ -23,7 +23,10 @@
     "geom:longitude":25.891875,
     "iso:country":"LV",
     "label:eng_x_preferred_longname":[
-        "Raunas Novads"
+        "Raunas Amalgamated Municipality"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "amalgamated municipality"
     ],
     "label:eng_x_preferred_shortcode":[
         "RN"
@@ -34,7 +37,7 @@
     "mps:latitude":57.234031,
     "mps:longitude":25.888831,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":10.0,
     "name:eng_x_preferred":[
@@ -86,7 +89,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1684354001,
+    "wof:lastmodified":1694493129,
     "wof:name":"Raunas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/11/85686211.geojson
+++ b/data/856/862/11/85686211.geojson
@@ -297,11 +297,17 @@
         "gn:id":7628310,
         "gp:id":-2346039,
         "hasc:id":"LV.RR",
+        "iso:code":"LV-079",
         "iso:id":"LV-079",
+        "qs:local_id":"8883",
         "wd:id":"Q2302986"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"c1d2f0d0a06c7b4f7100a52951ecbc41",
+    "wof:geomhash":"f185258f46a03d5f06f5e1728617cd71",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -316,7 +322,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938812,
+    "wof:lastmodified":1695885331,
     "wof:name":"Rojas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/15/85686215.geojson
+++ b/data/856/862/15/85686215.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3576,
     "eurostat:population_year":2020,
     "geom:area":0.072598,
-    "geom:area_square_m":484062490.189753,
+    "geom:area_square_m":484062295.672514,
     "geom:bbox":"24.785316,57.243857,25.38882,57.505626",
     "geom:latitude":57.368472,
     "geom:longitude":25.066836,
@@ -284,11 +284,17 @@
         "gn:id":7628373,
         "gp:id":-2346042,
         "hasc:id":"LV.PG",
+        "iso:code":"LV-070",
         "iso:id":"LV-070",
+        "qs:local_id":"4275",
         "wd:id":"Q2304831"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"514eff3e85ac408fc0782698b4e6bc65",
+    "wof:geomhash":"4c7798028d6444385c251c34de152382",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -303,7 +309,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938816,
+    "wof:lastmodified":1695885331,
     "wof:name":"Pargaujas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/21/85686221.geojson
+++ b/data/856/862/21/85686221.geojson
@@ -289,11 +289,17 @@
         "gn:id":7628298,
         "gp:id":-2346039,
         "hasc:id":"LV.DN",
+        "iso:code":"LV-027",
         "iso:id":"LV-027",
+        "qs:local_id":"8851",
         "wd:id":"Q2274832"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e0d3d66380fa24c4847a367787440c06",
+    "wof:geomhash":"0a2acdce6752af22ab069decbe1fd1d0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938813,
+    "wof:lastmodified":1695885331,
     "wof:name":"Dundagas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/25/85686225.geojson
+++ b/data/856/862/25/85686225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022717,
-    "geom:area_square_m":151577110.316594,
+    "geom:area_square_m":151577236.914044,
     "geom:bbox":"25.507552,57.26184,25.761642,57.443161",
     "geom:latitude":57.34174,
     "geom:longitude":25.64076,
@@ -270,11 +270,17 @@
         "gn:id":7628377,
         "gp:id":-2346042,
         "hasc:id":"LV.RN",
+        "iso:code":"LV-076",
         "iso:id":"LV-076",
+        "qs:local_id":"4277",
         "wd:id":"Q2124808"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"d6bcc2e10757f7e853c032d07a01d593",
+    "wof:geomhash":"a482dab690d5c9b8f6fad07def01aca2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -289,7 +295,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938816,
+    "wof:lastmodified":1695884324,
     "wof:name":"Raunas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/29/85686229.geojson
+++ b/data/856/862/29/85686229.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":7556,
     "eurostat:population_year":2020,
     "geom:area":0.045013,
-    "geom:area_square_m":300250452.368403,
+    "geom:area_square_m":300250467.411771,
     "geom:bbox":"25.22586,57.212052,25.667783,57.469586",
     "geom:latitude":57.354701,
     "geom:longitude":25.474789,
@@ -290,11 +290,17 @@
         "gn:id":7628376,
         "gp:id":-2346042,
         "hasc:id":"LV.PU",
+        "iso:code":"LV-075",
         "iso:id":"LV-075",
+        "qs:local_id":"4273",
         "wd:id":"Q2299231"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"b838388ba72dd28281f956330854be91",
+    "wof:geomhash":"0db050a337db12536a199c6dbced9608",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938813,
+    "wof:lastmodified":1695885331,
     "wof:name":"Priekulu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/35/85686235.geojson
+++ b/data/856/862/35/85686235.geojson
@@ -293,11 +293,17 @@
         "gn:id":461160,
         "gp:id":-2346020,
         "hasc:id":"LV.BV",
+        "iso:code":"LV-015",
         "iso:id":"LV-015",
+        "qs:local_id":"3802",
         "wd:id":"Q2018672"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e117b1e5fe446e7b0dddc035bd87f743",
+    "wof:geomhash":"6f447da845274717994179779ca847f1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938811,
+    "wof:lastmodified":1695885331,
     "wof:name":"Balvu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/41/85686241.geojson
+++ b/data/856/862/41/85686241.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":19771,
     "eurostat:population_year":2020,
     "geom:area":0.277992,
-    "geom:area_square_m":1863017266.913139,
+    "geom:area_square_m":1863017901.637109,
     "geom:bbox":"25.996354,56.943859,27.163065,57.409013",
     "geom:latitude":57.181408,
     "geom:longitude":26.599627,
@@ -287,11 +287,17 @@
         "gn:id":459664,
         "gp:id":-2346025,
         "hasc:id":"LV.GU",
+        "iso:code":"LV-033",
         "iso:id":"LV-033",
+        "qs:local_id":"5002",
         "wd:id":"Q209187"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"71ded51bff1fac13bbebc22b3426477e",
+    "wof:geomhash":"8c62f7b43d5c4275fcb39e26484f7b73",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -306,7 +312,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938815,
+    "wof:lastmodified":1695885332,
     "wof:name":"Gulbenes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/43/85686243.geojson
+++ b/data/856/862/43/85686243.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":23050,
     "eurostat:population_year":2020,
     "geom:area":0.002724,
-    "geom:area_square_m":18083595.788542,
+    "geom:area_square_m":18083630.072678,
     "geom:bbox":"25.374641,57.509444,25.467758,57.555111",
     "geom:latitude":57.532763,
     "geom:longitude":25.420564,
@@ -370,12 +370,18 @@
         "gn:id":454564,
         "gp:id":-2346042,
         "hasc:id":"LV.VE",
+        "iso:code":"LV-VMR",
         "iso:id":"LV-VMR",
+        "qs:local_id":"2500",
         "unlc:id":"LV-VMR",
         "wd:id":"Q108037"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"3c646e2da27cfc6ea3e5b57d59873994",
+    "wof:geomhash":"88933df6b085442c169b740bf13c63de",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -390,7 +396,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938814,
+    "wof:lastmodified":1695885332,
     "wof:name":"Valmiera",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/49/85686249.geojson
+++ b/data/856/862/49/85686249.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":11985,
     "eurostat:population_year":2020,
     "geom:area":0.141526,
-    "geom:area_square_m":942672174.27285,
+    "geom:area_square_m":942672232.890905,
     "geom:bbox":"25.655264,57.266506,26.326472,57.561157",
     "geom:latitude":57.406755,
     "geom:longitude":26.011708,
@@ -281,11 +281,17 @@
         "gn:id":7628380,
         "gp:id":-2346042,
         "hasc:id":"LV.SM",
+        "iso:code":"LV-094",
         "iso:id":"LV-094",
+        "qs:local_id":"9416",
         "wd:id":"Q1959984"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"2bc19321c4641ea79ba9d67b67dd74f6",
+    "wof:geomhash":"01e2060fa0a406595cf42f84956e5949",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +306,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938816,
+    "wof:lastmodified":1695885332,
     "wof:name":"Smiltenes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/51/85686251.geojson
+++ b/data/856/862/51/85686251.geojson
@@ -299,11 +299,17 @@
         "gn:id":7628348,
         "gp:id":-2346042,
         "hasc:id":"LV.VL",
+        "iso:code":"LV-108",
         "iso:id":"LV-108",
+        "qs:local_id":"3816",
         "wd:id":"Q1869075"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"fe55dfb1687a1a72dc996e9f24de7d3c",
+    "wof:geomhash":"ca5a8831691794daaad525458b6becb0",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -318,7 +324,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938812,
+    "wof:lastmodified":1695885332,
     "wof:name":"Vilakas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/57/85686257.geojson
+++ b/data/856/862/57/85686257.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":5783,
     "eurostat:population_year":2020,
     "geom:area":0.074787,
-    "geom:area_square_m":496359748.160011,
+    "geom:area_square_m":496359821.177743,
     "geom:bbox":"24.893669,57.383519,25.407853,57.674405",
     "geom:latitude":57.537599,
     "geom:longitude":25.191482,
@@ -286,11 +286,17 @@
         "gn:id":7628374,
         "gp:id":-2346042,
         "hasc:id":"LV.VR",
+        "iso:code":"LV-045",
         "iso:id":"LV-045",
+        "qs:local_id":"9602",
         "wd:id":"Q2304840"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"368cd86e02b6fa3c458fa0098426db51",
+    "wof:geomhash":"26fb690e1d5bad67086ad492d3c736fb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -305,7 +311,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938811,
+    "wof:lastmodified":1695885332,
     "wof:name":"Kocenu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/61/85686261.geojson
+++ b/data/856/862/61/85686261.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2927,
     "eurostat:population_year":2020,
     "geom:area":0.045218,
-    "geom:area_square_m":300226555.584932,
+    "geom:area_square_m":300226362.374684,
     "geom:bbox":"25.377132,57.430531,25.841133,57.622349",
     "geom:latitude":57.523183,
     "geom:longitude":25.595087,
@@ -290,11 +290,17 @@
         "gn:id":7628379,
         "gp:id":-2346042,
         "hasc:id":"LV.BE",
+        "iso:code":"LV-017",
         "iso:id":"LV-017",
+        "qs:local_id":"9647",
         "wd:id":"Q2018692"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"5a7438da2853ffb3b48de36deebd6bd6",
+    "wof:geomhash":"ae8d2c39514514e303b58a3eb74613b1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -309,7 +315,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938810,
+    "wof:lastmodified":1695885332,
     "wof:name":"Beverinas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/65/85686265.geojson
+++ b/data/856/862/65/85686265.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":16507,
     "eurostat:population_year":2020,
     "geom:area":0.175504,
-    "geom:area_square_m":1165468257.09876,
+    "geom:area_square_m":1165467830.632985,
     "geom:bbox":"24.3976,57.221449,25.090708,57.761603",
     "geom:latitude":57.51703,
     "geom:longitude":24.69496,
@@ -306,11 +306,17 @@
         "gn:id":457889,
         "gp:id":-2346031,
         "hasc:id":"LV.LI",
+        "iso:code":"LV-054",
         "iso:id":"LV-054",
+        "qs:local_id":"6602",
         "wd:id":"Q1579076"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"ea8db92777e153ccd3965fb59c04159b",
+    "wof:geomhash":"7f677a9436fbcebc86746024b3408221",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -325,7 +331,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938814,
+    "wof:lastmodified":1695885332,
     "wof:name":"Limba\u017eu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/69/85686269.geojson
+++ b/data/856/862/69/85686269.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":3220,
     "eurostat:population_year":2020,
     "geom:area":0.081629,
-    "geom:area_square_m":542816867.663578,
+    "geom:area_square_m":542816494.196746,
     "geom:bbox":"26.275006,57.315976,26.842579,57.58752",
     "geom:latitude":57.466953,
     "geom:longitude":26.521803,
@@ -473,11 +473,17 @@
         "gn:id":7628384,
         "gp:id":-2346042,
         "hasc:id":"LV.AP",
+        "iso:code":"LV-009",
         "iso:id":"LV-009",
+        "qs:local_id":"3608",
         "wd:id":"Q2343837"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"f9352459db51c321fae4b7fde8ea1f7d",
+    "wof:geomhash":"8fd84089213d867418c458695032df2b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -492,7 +498,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938812,
+    "wof:lastmodified":1695885332,
     "wof:name":"Apes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/75/85686275.geojson
+++ b/data/856/862/75/85686275.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2838,
     "eurostat:population_year":2020,
     "geom:area":0.05644,
-    "geom:area_square_m":373675393.264012,
+    "geom:area_square_m":373675540.211473,
     "geom:bbox":"25.505743,57.469576,25.994271,57.747277",
     "geom:latitude":57.626466,
     "geom:longitude":25.783912,
@@ -284,11 +284,17 @@
         "gn:id":7628378,
         "gp:id":-2346042,
         "hasc:id":"LV.ST",
+        "iso:code":"LV-096",
         "iso:id":"LV-096",
+        "qs:local_id":"9418",
         "wd:id":"Q2299223"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"6a453bbc85c726f91cfa6e73772e1ca9",
+    "wof:geomhash":"c061f5ed7aff8e440963713d477b5c0a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -303,7 +309,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938814,
+    "wof:lastmodified":1695885332,
     "wof:name":"Strencu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/79/85686279.geojson
+++ b/data/856/862/79/85686279.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":13895,
     "eurostat:population_year":2020,
     "geom:area":0.25359,
-    "geom:area_square_m":1688898312.186374,
+    "geom:area_square_m":1688898567.251367,
     "geom:bbox":"26.594788,57.225114,27.692582,57.633187",
     "geom:latitude":57.4112,
     "geom:longitude":27.152832,
@@ -323,11 +323,17 @@
         "gn:id":461525,
         "gp:id":-2346019,
         "hasc:id":"LV.AE",
+        "iso:code":"LV-007",
         "iso:id":"LV-007",
+        "qs:local_id":"3602",
         "wd:id":"Q3393445"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"ef3d8b42197935869fe3c4e6c257f59e",
+    "wof:geomhash":"cb47b8eb5416e7d3ceff896ec532fed5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -342,7 +348,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938815,
+    "wof:lastmodified":1695885332,
     "wof:name":"Aluksnes",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/83/85686283.geojson
+++ b/data/856/862/83/85686283.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":7369,
     "eurostat:population_year":2020,
     "geom:area":0.10581,
-    "geom:area_square_m":699110020.458016,
+    "geom:area_square_m":699110164.163638,
     "geom:bbox":"25.004852,57.540827,25.705023,57.848428",
     "geom:latitude":57.700729,
     "geom:longitude":25.35625,
@@ -286,11 +286,17 @@
         "gn:id":7628372,
         "gp:id":-2346042,
         "hasc:id":"LV.BT",
+        "iso:code":"LV-019",
         "iso:id":"LV-019",
+        "qs:local_id":"9671",
         "wd:id":"Q2079428"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"0eec5ba459af1f73bbb6ccf61d8386ca",
+    "wof:geomhash":"cb1db4555b49317505bfa6fb42e75441",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -305,7 +311,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938815,
+    "wof:lastmodified":1695885332,
     "wof:name":"Burtnieku",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/87/85686287.geojson
+++ b/data/856/862/87/85686287.geojson
@@ -293,11 +293,17 @@
         "gn:id":7628367,
         "gp:id":-2346037,
         "hasc:id":"LV.SL",
+        "iso:code":"LV-085",
         "iso:id":"LV-085",
+        "qs:local_id":"6614",
         "wd:id":"Q2251931"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"030322052d6732f5cfdb099548227dfe",
+    "wof:geomhash":"5186ff99ce8b1b264eaa23521d3c79a2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +318,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938813,
+    "wof:lastmodified":1695885332,
     "wof:name":"Salacgrivas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/93/85686293.geojson
+++ b/data/856/862/93/85686293.geojson
@@ -295,11 +295,17 @@
         "gn:id":7628368,
         "gp:id":-2346037,
         "hasc:id":"LV.AJ",
+        "iso:code":"LV-005",
         "iso:id":"LV-005",
+        "qs:local_id":"6610",
         "wd:id":"Q2989420"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"8634d1017d27009e6902847bcec2b40d",
+    "wof:geomhash":"a2b6f44d5974b75b15ec1055bc5f5691",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -314,7 +320,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938812,
+    "wof:lastmodified":1695885332,
     "wof:name":"Alojas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/95/85686295.geojson
+++ b/data/856/862/95/85686295.geojson
@@ -173,8 +173,14 @@
         "gn:id":454571,
         "gp:id":-2346041,
         "hasc:id":"LV.VA",
-        "iso:id":"LV-101"
+        "iso:code":"LV-101",
+        "iso:id":"LV-101",
+        "qs:local_id":"9402"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
     "wof:geomhash":"9979f41f4580457f34a265e6b2d17643",
     "wof:hierarchy":[
@@ -191,7 +197,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1684354001,
+    "wof:lastmodified":1695885332,
     "wof:name":"Valkas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/862/99/85686299.geojson
+++ b/data/856/862/99/85686299.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":1675,
     "eurostat:population_year":2020,
     "geom:area":0.042483,
-    "geom:area_square_m":279094445.665576,
+    "geom:area_square_m":279094327.224114,
     "geom:bbox":"25.26397,57.780091,25.702177,57.995705",
     "geom:latitude":57.906741,
     "geom:longitude":25.477039,
@@ -292,11 +292,17 @@
         "gn:id":7628369,
         "gp:id":-2346042,
         "hasc:id":"LV.NA",
+        "iso:code":"LV-064",
         "iso:id":"LV-064",
+        "qs:local_id":"9673",
         "wd:id":"Q773027"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e7afc0574a93de669d3bda83001c0ea3",
+    "wof:geomhash":"b98606991d411c584020cbd7f934e91b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -311,7 +317,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938814,
+    "wof:lastmodified":1695885332,
     "wof:name":"Nauksenu",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/863/03/85686303.geojson
+++ b/data/856/863/03/85686303.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":2880,
     "eurostat:population_year":2020,
     "geom:area":0.063231,
-    "geom:area_square_m":415339536.168388,
+    "geom:area_square_m":415339906.370278,
     "geom:bbox":"24.832779,57.796514,25.260178,58.066384",
     "geom:latitude":57.912297,
     "geom:longitude":25.034141,
@@ -288,11 +288,17 @@
         "gn:id":7628371,
         "gp:id":-2346042,
         "hasc:id":"LV.MZ",
+        "iso:code":"LV-060",
         "iso:id":"LV-060",
+        "qs:local_id":"9610",
         "wd:id":"Q2283334"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"e779a476adb06aa9bd986a5a92290a60",
+    "wof:geomhash":"e5d7ed0077ff337d148d3e3bd42b7c77",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -307,7 +313,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938816,
+    "wof:lastmodified":1695885332,
     "wof:name":"Mazsalacas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",

--- a/data/856/863/05/85686305.geojson
+++ b/data/856/863/05/85686305.geojson
@@ -17,7 +17,7 @@
     "eurostat:population":4824,
     "eurostat:population_year":2020,
     "geom:area":0.053461,
-    "geom:area_square_m":350922997.548681,
+    "geom:area_square_m":350922735.68811,
     "geom:bbox":"25.097159,57.778245,25.471302,58.085571",
     "geom:latitude":57.936868,
     "geom:longitude":25.278727,
@@ -289,11 +289,17 @@
         "gn:id":7628370,
         "gp:id":-2346042,
         "hasc:id":"LV.RU",
+        "iso:code":"LV-084",
         "iso:id":"LV-084",
+        "qs:local_id":"9616",
         "wd:id":"Q2299415"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"LV",
-    "wof:geomhash":"ca16312e560d034e028cf52cd4d3f423",
+    "wof:geomhash":"78f8402c0b1e98913a6da74e2178ae25",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -308,7 +314,7 @@
     "wof:lang_x_spoken":[
         "lav"
     ],
-    "wof:lastmodified":1690938817,
+    "wof:lastmodified":1695885333,
     "wof:name":"Rujienas",
     "wof:parent_id":85633279,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.